### PR TITLE
fix: sort pickup locations by distance (#37)

### DIFF
--- a/src/config/defaultConfiguration.js
+++ b/src/config/defaultConfiguration.js
@@ -61,8 +61,9 @@ export const defaultConfiguration = (platform = DEFAULT_PLATFORM) => {
       [CONFIG.PRICE_STANDARD_DELIVERY]: DEFAULT_PRICE,
 
       [CONFIG.FEATURE_ALLOW_RETRY]: true,
-      [CONFIG.FEATURE_PICKUP_LOCATIONS_DEFAULT_VIEW]: 'map',
       [CONFIG.FEATURE_MAX_PAGE_ITEMS]: 5,
+      [CONFIG.FEATURE_PICKUP_LOCATIONS_DEFAULT_VIEW]: 'map',
+      [CONFIG.FEATURE_PICKUP_SHOW_DISTANCE]: true,
 
       /**
        * Default leaflet tile layer data.

--- a/src/delivery-options/components/Pickup/PickupOption.vue
+++ b/src/delivery-options/components/Pickup/PickupOption.vue
@@ -70,7 +70,7 @@ export default {
   },
   computed: {
     featurePickupShowDistance() {
-      return this.$configBus.get(CONFIG.FEATURE_PICKUP_SHOW_DISTANCE) !== false;
+      return this.$configBus.isEnabled(CONFIG.FEATURE_PICKUP_SHOW_DISTANCE);
     },
 
     pickupData() {

--- a/src/delivery-options/config/configBus.js
+++ b/src/delivery-options/config/configBus.js
@@ -390,15 +390,16 @@ export const createConfigBus = (eventCallee = null) => {
        * @param {MyParcel.CarrierName|Number} obj.value - New carrier or pickup location id.
        */
       updateCurrentCarrier({ name, value }) {
-        switch (name) {
-          case FORM.CARRIER:
-            this.currentCarrier = value;
-            break;
-          case FORM.PICKUP_LOCATION:
-            if (this.pickupLocations.hasOwnProperty(value)) {
-              this.currentCarrier = this.pickupLocations[value].carrier;
-            }
-            break;
+        if (FORM.CARRIER === name) {
+          this.currentCarrier = value;
+        } else if (FORM.PICKUP_LOCATION === name) {
+          const foundPickupLocation = this.pickupLocations.find((pickupLocation) => {
+            return pickupLocation.location_code === value;
+          });
+
+          if (foundPickupLocation) {
+            this.currentCarrier = foundPickupLocation.carrier;
+          }
         }
 
         this.values[FORM.CARRIER] = this.currentCarrier;

--- a/src/delivery-options/config/exports/PickupExportValues.js
+++ b/src/delivery-options/config/exports/PickupExportValues.js
@@ -32,13 +32,17 @@ export class PickupExportValues extends ExportValues {
       return;
     }
 
+    const foundLocation = configBus.pickupLocations.find((data) => {
+      return data.location_code === pickupLocationName;
+    });
+
     /*
      * After changing address while pickup is selected, the current pickupLocation might not be updated yet. This
      *  causes an error because the old pickup location likely doesn't exist anymore in the pickupLocations array.
      *
      * Return, because the next time pickupLocation will be set this condition will pass.
      */
-    if (!configBus.pickupLocations.hasOwnProperty(pickupLocationName)) {
+    if (!foundLocation) {
       return;
     }
 
@@ -46,7 +50,7 @@ export class PickupExportValues extends ExportValues {
      * Take out the possibilities array to use it to get the deliveryDate, but don't add it to the exportValues.
      * Also remove carrier from the pickupLocation object because it's already set in exportValues.carrier.
      */
-    const { carrier, possibilities, ...pickupLocation } = configBus.pickupLocations[pickupLocationName];
+    const { carrier, possibilities, ...pickupLocation } = foundLocation;
 
     this.deliveryDate = getPickupDate(possibilities);
     this.pickupLocation = pickupLocation;

--- a/src/delivery-options/data/pickup/createPickupChoices.js
+++ b/src/delivery-options/data/pickup/createPickupChoices.js
@@ -18,7 +18,7 @@ export async function createPickupChoices(createRequestCallback = (carrier) => f
   let { responses } = await fetchMultiple(requests);
 
   if (!responses.length) {
-    throw new Error('No pickup locations found.');
+    return [];
   }
 
   responses = sortPickupLocations(responses);

--- a/src/delivery-options/data/pickup/formatPickupLocations.js
+++ b/src/delivery-options/data/pickup/formatPickupLocations.js
@@ -1,24 +1,21 @@
 /**
  * Format the pickup locations responses.
  *
- * @param {Array} responses - Responses array from pickup locations request.
+ * @param {Array} pickupLocations - Responses array from pickup locations request.
  *
  * @returns {Object[]}
  */
-export function formatPickupLocations(responses) {
-  return responses.reduce((acc, { carrier, location, address, possibilities }) => {
+export function formatPickupLocations(pickupLocations) {
+  return pickupLocations.map(({ carrier, location, address, possibilities }) => {
     const { retail_network_id, location_code, location_name } = location;
 
     return {
-      ...acc,
-      [location_code]: {
-        carrier: carrier.name,
-        location_name,
-        location_code,
-        retail_network_id,
-        possibilities,
-        ...address,
-      },
+      carrier: carrier.name,
+      location_name,
+      location_code,
+      retail_network_id,
+      possibilities,
+      ...address,
     };
-  }, {});
+  });
 }

--- a/tests/unit/delivery-options/components/pickup/Pickup.spec.js
+++ b/tests/unit/delivery-options/components/pickup/Pickup.spec.js
@@ -31,10 +31,10 @@ describe('Pickup.vue', () => {
     }, Pickup);
   });
 
-  it('createPickupChoices with error', async() => {
+  it('handle finding no pickup locations', async() => {
     expect.assertions(1);
     fakePickupLocationsResponse.mockImplementationOnce(() => []);
-    await expect(createPickupChoices()).rejects.toThrow(Error);
+    await expect(createPickupChoices()).resolves.toStrictEqual([]);
   });
 
   it('shows map view by default', () => {


### PR DESCRIPTION
- pickupLocations is now an array of objects, not an object
- not finding pickup locations doesn't throw an error anymore

Closes #37 