### PR TITLE
feat: add "active" classes to selected elements

### DIFF
--- a/src/delivery-options/components/CButton.vue
+++ b/src/delivery-options/components/CButton.vue
@@ -1,11 +1,19 @@
 <template>
   <button
-    :class="$classBase + '__button'"
+    :class="{
+      [$classBase + '__button']: true,
+      [$classBase + '__button--selected']: isSelected,
+    }"
     @click="(event) => $emit('click', event)" />
 </template>
 
 <script>
 export default {
   name: 'CButton',
+  props: {
+    isSelected: {
+      type: Boolean,
+    },
+  },
 };
 </script>

--- a/src/delivery-options/components/Pickup/Pickup.vue
+++ b/src/delivery-options/components/Pickup/Pickup.vue
@@ -3,11 +3,13 @@
     <div class="pb-2">
       <CButton
         v-test="'button--list'"
+        :is-selected="selected === views.list"
         @click="selected = views.list"
         v-text="$configBus.strings.pickupLocationsListButton" />
       <CButton
         v-test="'button--map'"
         class="ml-1"
+        :is-selected="selected === views.map"
         @click="selected = views.map"
         v-text="$configBus.strings.pickupLocationsMapButton" />
     </div>

--- a/src/delivery-options/components/RecursiveForm/RecursiveForm.vue
+++ b/src/delivery-options/components/RecursiveForm/RecursiveForm.vue
@@ -26,6 +26,8 @@
         [`${$classBase}__choice`]: true,
         [`${$classBase}__choice--has-image`]: choice.hasOwnProperty('image'),
         [`${$classBase}__choice--disabled`]: choice.disabled,
+        [`${$classBase}__choice--${choice.name}`]: true,
+        [`${$classBase}__choice--selected`]: isSelected(choice),
       }">
       <td
         v-if="mutableOption.type !== 'heading'"


### PR DESCRIPTION
- Resolves #8
- Resolves #62

### Changes
- Buttons now get the class `myparcel-delivery-options__button--selected` when they are selected.
- The `tr` of a choice now get the choice name and a selected class. For example, the `Delivery > Evening` option now has the following classes when it's selected:
  - `myparcel-delivery-options__choice--evening`: name of the choice, always present
  - `myparcel-delivery-options__choice--selected`: present if it's selected