### PR TITLE
fix(pickup): fix map not reloading on address change

### DIFF
--- a/apps/delivery-options/src/components/map/LeafletMapInner/LeafletMapInner.vue
+++ b/apps/delivery-options/src/components/map/LeafletMapInner/LeafletMapInner.vue
@@ -10,7 +10,7 @@
 /* eslint-disable new-cap */
 import {computed, onActivated, onMounted, onUnmounted, provide, ref, toRefs, watch} from 'vue';
 import {isString} from 'radash';
-import {type Control, type Map, type Marker, type TileLayer, type LatLng} from 'leaflet';
+import {type Control, type Map, type Marker, type TileLayer, type LatLng, type FeatureGroup} from 'leaflet';
 import {isDef, useScriptTag, useStyleTag, useDebounceFn} from '@vueuse/core';
 import {type MapTileLayerData} from '@myparcel-do/shared';
 import {type LeafletMapProps} from '../../../types';
@@ -64,10 +64,15 @@ const fitBounds = useDebounceFn(() => {
     return;
   }
 
-  const group = new L.featureGroup(markers.value as Marker[]);
+  const group: FeatureGroup = new L.featureGroup(markers.value as Marker[]);
 
   map.value?.setView(getActiveMarkerLatLng() ?? props.center, props.zoom);
-  map.value?.fitBounds(group.getBounds());
+
+  const bounds = group.getBounds();
+
+  if (bounds.isValid()) {
+    map.value?.fitBounds(bounds);
+  }
 }, 50);
 
 onMounted(() => {

--- a/apps/delivery-options/src/components/map/LeafletMapInner/LeafletMapInner.vue
+++ b/apps/delivery-options/src/components/map/LeafletMapInner/LeafletMapInner.vue
@@ -60,6 +60,10 @@ const getActiveMarkerLatLng = (): undefined | LatLng => {
 };
 
 const fitBounds = useDebounceFn(() => {
+  if (!container.value) {
+    return;
+  }
+
   const group = new L.featureGroup(markers.value as Marker[]);
 
   map.value?.setView(getActiveMarkerLatLng() ?? props.center, props.zoom);

--- a/apps/delivery-options/src/composables/usePickupLocation.ts
+++ b/apps/delivery-options/src/composables/usePickupLocation.ts
@@ -1,35 +1,33 @@
 import {computed, type MaybeRef, type ComputedRef} from 'vue';
-import {get, useMemoize} from '@vueuse/core';
+import {get} from '@vueuse/core';
 import {type ResolvedPickupLocation} from '../types';
 import {useResolvedPickupLocations} from './useResolvedPickupLocations';
 import {useResolvedCarrier, type UseResolvedCarrier} from './useResolvedCarrier';
 
-export const getFullPickupLocation = useMemoize((locationCode: string): ResolvedPickupLocation | undefined => {
+export const getFullPickupLocation = (locationCode: string): ResolvedPickupLocation | undefined => {
   const locations = useResolvedPickupLocations();
 
   return (locations.value ?? []).find((location) => location.locationCode === get(locationCode));
-});
+};
 
 type UsePickupLocation = {
-  pickupLocation: ComputedRef<ResolvedPickupLocation>;
-  resolvedCarrier: ComputedRef<UseResolvedCarrier>;
+  pickupLocation: ComputedRef<ResolvedPickupLocation | undefined>;
+  resolvedCarrier: ComputedRef<UseResolvedCarrier | undefined>;
 };
 
 export const usePickupLocation = (locationCode: MaybeRef<string>): UsePickupLocation => {
   const pickupLocation = computed(() => {
-    const result = getFullPickupLocation(get(locationCode));
-
-    if (!result) {
-      throw new Error(`Pickup location not found: ${get(locationCode)}`);
-    }
-
-    return result;
+    return getFullPickupLocation(get(locationCode));
   });
 
   const resolvedCarrier = computed(() => {
-    const carrierIdentifier = pickupLocation.value.carrier;
+    const carrierIdentifier = pickupLocation.value?.carrier;
 
-    return useResolvedCarrier(carrierIdentifier);
+    if (carrierIdentifier) {
+      return useResolvedCarrier(carrierIdentifier);
+    }
+
+    return undefined;
   });
 
   return {

--- a/apps/delivery-options/src/composables/useResolvedPickupLocations.ts
+++ b/apps/delivery-options/src/composables/useResolvedPickupLocations.ts
@@ -4,6 +4,7 @@ import {type PickupLocation} from '@myparcel/sdk';
 import {DeliveryTypeName} from '@myparcel/constants';
 import {createGetDeliveryOptionsParameters} from '../utils';
 import {type ResolvedPickupLocation} from '../types';
+import {useAddressStore} from '../stores';
 import {type UseResolvedCarrier} from './useResolvedCarrier';
 import {useActiveCarriers} from './useActiveCarriers';
 
@@ -57,6 +58,14 @@ const loadPickupLocations = async (carrier: UseResolvedCarrier) => {
   return locations.map((location) => formatPickupLocation(carrier, location as PickupLocation));
 };
 
+const pickupMemoizeOpts = {
+  getKey() {
+    // Cache per address, so the locations are reloaded when the address changes
+    // Not ideal, but otherwise the address would have to be passed as a parameter to the composable
+    return JSON.stringify(useAddressStore().$state);
+  },
+};
+
 export const useResolvedPickupLocations = useMemoize(() => {
   const carriers = useActiveCarriers();
 
@@ -69,4 +78,4 @@ export const useResolvedPickupLocations = useMemoize(() => {
 
     return result.map((locations) => locations.sort(sortByDistance)).flat(1);
   }, []);
-});
+}, pickupMemoizeOpts);

--- a/apps/delivery-options/src/utils/getResolvedCarrier.ts
+++ b/apps/delivery-options/src/utils/getResolvedCarrier.ts
@@ -35,7 +35,6 @@ export const getResolvedCarrier = (
   platformName: SupportedPlatformName,
 ): UseResolvedCarrier => {
   const carrier = useCarrier({carrierIdentifier, platformName});
-  const address = useAddressStore();
 
   const disabledDeliveryTypes = ref(new Set<SupportedDeliveryTypeName>());
 
@@ -56,18 +55,20 @@ export const getResolvedCarrier = (
   });
 
   const hasFakeDelivery = computed(() => {
+    const {cc} = useAddressStore(); // Only when defined here is the cc not stale
     return (
       getResolvedValue(CarrierSetting.AllowDeliveryOptions, carrierIdentifier) &&
       carrier.fakeDelivery.value &&
-      !carrier.deliveryCountries.value.has(address.cc) &&
-      !carrier.fakeDeliveryBlacklist.value.has(address.cc)
+      !carrier.deliveryCountries.value.has(cc) &&
+      !carrier.fakeDeliveryBlacklist.value.has(cc)
     );
   });
 
   const hasDelivery = computed(() => {
+    const {cc} = useAddressStore(); // Only when defined here is the cc not stale
     return (
       getResolvedValue(CarrierSetting.AllowDeliveryOptions, carrierIdentifier) &&
-      carrier.deliveryCountries.value.has(address.cc) &&
+      carrier.deliveryCountries.value.has(cc) &&
       DELIVERY_TYPES.some((deliveryType) => {
         const configKey = getConfigKey(deliveryType);
         const value = getResolvedValue(configKey, carrierIdentifier);
@@ -78,9 +79,8 @@ export const getResolvedCarrier = (
   });
 
   const hasPickup = computed(() => {
-    const address = useAddressStore();
-
-    return deliveryTypes.value.has(DeliveryTypeName.Pickup) && carrier.pickupCountries.value.has(address.cc);
+    const {cc} = useAddressStore(); // Only when defined here is the cc not stale
+    return deliveryTypes.value.has(DeliveryTypeName.Pickup) && carrier.pickupCountries.value.has(cc);
   });
 
   return {

--- a/apps/delivery-options/src/views/MyParcelDeliveryOptions/Pickup/PickupLocationList/PickupLocationListItem.vue
+++ b/apps/delivery-options/src/views/MyParcelDeliveryOptions/Pickup/PickupLocationList/PickupLocationListItem.vue
@@ -1,13 +1,15 @@
 <template>
-  <div class="mp-flex-grow">
-    <PickupLocationName :location-code="locationCode" />
-  </div>
+  <template v-if="pickupLocation">
+    <div class="mp-flex-grow">
+      <PickupLocationName :location-code="locationCode" />
+    </div>
 
-  <span v-text="distance" />
+    <span v-text="distance" />
 
-  <CarrierLogo
-    v-if="pickupLocation.carrier"
-    :carrier="pickupLocation.carrier" />
+    <CarrierLogo
+      v-if="pickupLocation.carrier"
+      :carrier="pickupLocation.carrier" />
+  </template>
 </template>
 
 <script lang="ts" setup>
@@ -21,7 +23,7 @@ const propRefs = toRefs(props);
 
 const {pickupLocation} = usePickupLocation(propRefs.locationCode);
 
-const plainDistance = computed(() => pickupLocation.value.distance);
+const plainDistance = computed(() => pickupLocation.value?.distance);
 
 const distance = useFormatDistance(plainDistance);
 </script>

--- a/apps/delivery-options/src/views/MyParcelDeliveryOptions/Pickup/PickupLocationMap/PickupLocationDetails.vue
+++ b/apps/delivery-options/src/views/MyParcelDeliveryOptions/Pickup/PickupLocationMap/PickupLocationDetails.vue
@@ -1,11 +1,13 @@
 <template>
-  <div class="mp-flex mp-flex-col mp-gap-2">
+  <div
+    v-if="pickupLocation"
+    class="mp-flex mp-flex-col mp-gap-2">
     <div class="mp-flex mp-gap-2 mp-items-center">
       <CarrierLogo
         v-if="pickupLocation.carrier"
         :carrier="pickupLocation.carrier" />
 
-      <b v-text="carrier.human" />
+      <b v-text="carrier?.human" />
 
       <PriceTag
         v-if="price !== undefined"
@@ -39,7 +41,7 @@ const {pickupLocation, resolvedCarrier} = usePickupLocation(propRefs.locationCod
 
 const price = ref();
 
-const carrier = computed(() => resolvedCarrier.value.carrier.value);
+const carrier = computed(() => resolvedCarrier.value?.carrier.value);
 
 watchImmediate(propRefs.locationCode, () => {
   if (!resolvedCarrier.value) {

--- a/apps/delivery-options/src/views/MyParcelDeliveryOptions/Pickup/PickupLocationMapMarker/PickupLocationMapMarker.vue
+++ b/apps/delivery-options/src/views/MyParcelDeliveryOptions/Pickup/PickupLocationMapMarker/PickupLocationMapMarker.vue
@@ -21,7 +21,8 @@ const propRefs = toRefs(props);
 const form = useDeliveryOptionsForm();
 
 const {pickupLocation} = usePickupLocation(propRefs.locationCode);
-const carrier = useResolvedCarrier(pickupLocation.value.carrier);
+
+const carrier = useResolvedCarrier(pickupLocation.value?.carrier);
 
 const center = computed(() => {
   if (!isDef(pickupLocation.value)) {
@@ -34,7 +35,7 @@ const center = computed(() => {
 });
 
 const options = computed<MarkerOptions>(() => {
-  const resolvedCarrier = carrier.carrier.value;
+  const resolvedCarrier = carrier?.carrier.value;
 
   if (!pickupLocation.value || !resolvedCarrier) {
     return {};
@@ -54,6 +55,6 @@ const options = computed<MarkerOptions>(() => {
 const {pickupLocation: selectedPickupLocation} = useSelectedValues();
 
 const onClick = () => {
-  selectedPickupLocation.value = pickupLocation.value.locationCode;
+  selectedPickupLocation.value = pickupLocation.value?.locationCode;
 };
 </script>

--- a/apps/delivery-options/src/views/MyParcelDeliveryOptions/Pickup/PickupLocations.vue
+++ b/apps/delivery-options/src/views/MyParcelDeliveryOptions/Pickup/PickupLocations.vue
@@ -22,15 +22,15 @@
 import {computed, ref, watch, onUnmounted} from 'vue';
 import {PickupLocationsView} from '@myparcel-do/shared';
 import {useConfigStore} from '../../../stores';
-import {useLanguage, useResolvedPickupLocations, useSelectedValues} from '../../../composables';
+import {useLanguage, useResolvedPickupLocations, useSelectedValues, useActiveCarriers} from '../../../composables';
 import {DoButton} from '../../../components';
 import PickupLocationMapWrapper from './PickupLocationMap/PickupLocationMapWrapper.vue';
 import PickupLocationListWrapper from './PickupLocationList/PickupLocationListWrapper.vue';
 import PickupLocationInput from './PickupLocationInput/PickupLocationInput.vue';
 
 const config = useConfigStore();
-const locations = useResolvedPickupLocations();
 
+const locations = useResolvedPickupLocations();
 const mode = ref<PickupLocationsView>(config.pickupLocationsDefaultView);
 
 const {translate} = useLanguage();
@@ -42,6 +42,12 @@ const currentComponent = computed(() =>
 const immediate = locations.value.length > 0;
 
 const {pickupLocation: selectedPickupLocation} = useSelectedValues();
+
+// Clear the carries and locations memoize cache, otherwise reactivity issues may occur on mount with different config.
+onUnmounted(() => {
+  useActiveCarriers.clear();
+  useResolvedPickupLocations.clear();
+});
 
 onUnmounted(
   watch(

--- a/libs/shared/src/data/errors.ts
+++ b/libs/shared/src/data/errors.ts
@@ -32,6 +32,7 @@ export const IGNORED_ERRORS = Object.freeze([
   0,
   ERROR_INVALID_COUNTRY_CODE,
   ERROR_INVALID_CARRIER_PLATFORM_COMBINATION,
+  ERROR_COUNTRY_NOT_SUPPORTED_BY_CARRIER,
 ]);
 
 export const ERROR_REPLACE_MAP: Record<number, number> = Object.freeze({


### PR DESCRIPTION
Works around an issue where the pickup locations would never refresh, due to memoization not having any arguments to build a cache key from when loading available pickup locations.

INT-464