### PR TITLE
fix: fix capabilities for carriers on be platform

### DIFF
--- a/libs/shared/src/config/getSendMyParcelConfig.ts
+++ b/libs/shared/src/config/getSendMyParcelConfig.ts
@@ -49,7 +49,7 @@ export const getSendMyParcelConfig = (): PlatformConfiguration => ({
       name: CarrierName.PostNl,
       subscription: SubscriptionType.Never,
       packageTypes: [PackageTypeName.Package],
-      deliveryTypes: [DeliveryTypeName.Standard, DeliveryTypeName.Pickup],
+      deliveryTypes: [DeliveryTypeName.Standard, DeliveryTypeName.Pickup, CustomDeliveryType.Saturday],
       deliveryCountries: [BELGIUM, NETHERLANDS],
       pickupCountries: [BELGIUM, NETHERLANDS],
       shipmentOptions: [ShipmentOptionName.OnlyRecipient, ShipmentOptionName.Signature],

--- a/libs/shared/src/config/getSendMyParcelConfig.ts
+++ b/libs/shared/src/config/getSendMyParcelConfig.ts
@@ -42,7 +42,7 @@ export const getSendMyParcelConfig = (): PlatformConfiguration => ({
       pickupCountries: [BELGIUM, NETHERLANDS],
       features: [CarrierSetting.DeliveryDaysWindow, CarrierSetting.DropOffDays, CarrierSetting.DropOffDelay],
       addressFields: [AddressField.PostalCode, AddressField.Street, AddressField.City],
-      shipmentOptions: [ShipmentOptionName.OnlyRecipient, ShipmentOptionName.Signature],
+      shipmentOptions: [ShipmentOptionName.Signature],
     },
     {
       name: CarrierName.PostNl,
@@ -51,7 +51,7 @@ export const getSendMyParcelConfig = (): PlatformConfiguration => ({
       deliveryTypes: [DeliveryTypeName.Standard, DeliveryTypeName.Pickup],
       deliveryCountries: [BELGIUM, NETHERLANDS],
       pickupCountries: [BELGIUM, NETHERLANDS],
-      shipmentOptions: [ShipmentOptionName.Signature],
+      shipmentOptions: [ShipmentOptionName.OnlyRecipient, ShipmentOptionName.Signature],
       features: [CarrierSetting.DeliveryDaysWindow, CarrierSetting.DropOffDays, CarrierSetting.DropOffDelay],
     },
     {

--- a/libs/shared/src/config/getSendMyParcelConfig.ts
+++ b/libs/shared/src/config/getSendMyParcelConfig.ts
@@ -43,6 +43,7 @@ export const getSendMyParcelConfig = (): PlatformConfiguration => ({
       features: [CarrierSetting.DeliveryDaysWindow, CarrierSetting.DropOffDays, CarrierSetting.DropOffDelay],
       addressFields: [AddressField.PostalCode, AddressField.Street, AddressField.City],
       shipmentOptions: [ShipmentOptionName.Signature],
+      fakeDelivery: true,
     },
     {
       name: CarrierName.PostNl,
@@ -53,6 +54,7 @@ export const getSendMyParcelConfig = (): PlatformConfiguration => ({
       pickupCountries: [BELGIUM, NETHERLANDS],
       shipmentOptions: [ShipmentOptionName.OnlyRecipient, ShipmentOptionName.Signature],
       features: [CarrierSetting.DeliveryDaysWindow, CarrierSetting.DropOffDays, CarrierSetting.DropOffDelay],
+      fakeDelivery: true,
     },
     {
       name: CarrierName.Dpd,

--- a/libs/shared/src/utils/__snapshots__/getPlatformConfig.spec.ts.snap
+++ b/libs/shared/src/utils/__snapshots__/getPlatformConfig.spec.ts.snap
@@ -46,6 +46,7 @@ exports[`getPlatformConfig > gets config for platform belgie 1`] = `
       "deliveryTypes": [
         "standard",
         "pickup",
+        "saturday",
       ],
       "fakeDelivery": true,
       "features": [

--- a/libs/shared/src/utils/__snapshots__/getPlatformConfig.spec.ts.snap
+++ b/libs/shared/src/utils/__snapshots__/getPlatformConfig.spec.ts.snap
@@ -33,7 +33,6 @@ exports[`getPlatformConfig > gets config for platform belgie 1`] = `
         "NL",
       ],
       "shipmentOptions": [
-        "only_recipient",
         "signature",
       ],
       "subscription": 0,
@@ -61,6 +60,7 @@ exports[`getPlatformConfig > gets config for platform belgie 1`] = `
         "NL",
       ],
       "shipmentOptions": [
+        "only_recipient",
         "signature",
       ],
       "subscription": 0,

--- a/libs/shared/src/utils/__snapshots__/getPlatformConfig.spec.ts.snap
+++ b/libs/shared/src/utils/__snapshots__/getPlatformConfig.spec.ts.snap
@@ -18,6 +18,7 @@ exports[`getPlatformConfig > gets config for platform belgie 1`] = `
         "pickup",
         "saturday",
       ],
+      "fakeDelivery": true,
       "features": [
         "deliveryDaysWindow",
         "dropOffDays",
@@ -46,6 +47,7 @@ exports[`getPlatformConfig > gets config for platform belgie 1`] = `
         "standard",
         "pickup",
       ],
+      "fakeDelivery": true,
       "features": [
         "deliveryDaysWindow",
         "dropOffDays",


### PR DESCRIPTION
- remove only recipient from bpost
- add only recipient to postnl
- enables "fake delivery" for bpost and postnl. (This allows simple delivery options to all countries not in the `deliveryCountries` list.)