### PR TITLE
fix(pickup): fix list locations for disabled carriers staying visible

### DIFF
--- a/apps/delivery-options/src/composables/useResolvedPickupLocations.spec.ts
+++ b/apps/delivery-options/src/composables/useResolvedPickupLocations.spec.ts
@@ -1,31 +1,66 @@
-import {describe, it, beforeEach, expect} from 'vitest';
+import {describe, it, beforeEach, expect, afterEach, vi} from 'vitest';
 import {createPinia, setActivePinia} from 'pinia';
+import {flushPromises} from '@vue/test-utils';
+import {mockGetPickupLocations, fakePickupLocationsResponse} from '@myparcel-do/shared/testing';
+import {KEY_CONFIG, ConfigSetting, CarrierSetting, KEY_CARRIER_SETTINGS} from '@myparcel-do/shared';
 import {CarrierName} from '@myparcel/constants';
 import {
   mockDeliveryOptionsConfig,
+  getMockDeliveryOptionsConfiguration,
   mockDeliveryOptionsForm,
-  waitForDeliveryOptions,
   waitForPickupLocations,
 } from '../__tests__';
 import {useResolvedPickupLocations} from './useResolvedPickupLocations';
 
+async function load(): Promise<void> {
+  await Promise.all([mockDeliveryOptionsForm(), waitForPickupLocations()]);
+}
+
 describe('useResolvedPickupLocations', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     setActivePinia(createPinia());
 
-    mockDeliveryOptionsConfig();
-
-    await Promise.all([mockDeliveryOptionsForm(), waitForDeliveryOptions(), waitForPickupLocations()]);
+    mockDeliveryOptionsConfig(
+      getMockDeliveryOptionsConfiguration({
+        [KEY_CONFIG]: {
+          [ConfigSetting.PickupMapAllowLoadMore]: true,
+          [KEY_CARRIER_SETTINGS]: {
+            [CarrierName.PostNl]: {
+              [CarrierSetting.AllowPickupLocations]: true,
+            },
+            [CarrierName.DhlForYou]: {
+              [CarrierSetting.AllowPickupLocations]: false,
+            },
+            [`${CarrierName.DhlForYou}:123`]: {
+              [CarrierSetting.AllowPickupLocations]: true,
+            },
+            [CarrierName.Dpd]: {
+              [CarrierSetting.AllowPickupLocations]: false,
+            },
+          },
+        },
+      }),
+    );
   });
 
-  it('loads pickup locations', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('loads pickup locations', async () => {
+    const fakeResponse = fakePickupLocationsResponse();
+    expect.assertions(1 + fakeResponse.length * 2);
+
+    await load();
+
     const {locations} = useResolvedPickupLocations();
 
-    expect(locations.value.length).toBeGreaterThan(0);
+    // For each carrier that has pickup, this response should be returned.
+    expect(locations.value.length).toBe(fakeResponse.length * 2);
 
     locations.value.forEach((location) => {
       expect(location).toMatchObject({
-        carrier: CarrierName.PostNl,
+        carrier: expect.any(String),
         locationCode: expect.any(String),
         locationName: expect.any(String),
         latitude: expect.any(Number),
@@ -38,5 +73,42 @@ describe('useResolvedPickupLocations', () => {
         openingHours: expect.any(Array),
       });
     });
+  });
+
+  it('loads more location using latitude and longitude', async () => {
+    expect.assertions(2);
+    await load();
+
+    const {loadMoreLocations, locations} = useResolvedPickupLocations();
+
+    const initialLength = locations.value.length;
+
+    const newLocation = {...fakePickupLocationsResponse()[0]};
+
+    newLocation.location.location_name = 'New location found with LatLng';
+    // Locations are deduplicated by location_code, so we need to change this to make it unique
+    newLocation.location.location_code = 'some-location-code';
+
+    mockGetPickupLocations.mockReturnValueOnce([newLocation]);
+
+    await loadMoreLocations(52.378, 4.9);
+    await flushPromises();
+
+    // Expect new locations to have been fetched and added to the list
+    expect(locations.value.length).toBe(initialLength + 1);
+    // One for each carrier and one for getting the new location. Only PostNL can use the latitude and longitude option.
+    expect(mockGetPickupLocations).toHaveBeenCalledTimes(3);
+  });
+
+  it('can reset pickup locations array', async () => {
+    await load();
+
+    const {locations, reset} = useResolvedPickupLocations();
+
+    expect(locations.value.length).toBeGreaterThan(0);
+
+    reset();
+
+    expect(locations.value.length).toBe(0);
   });
 });

--- a/apps/delivery-options/src/composables/useResolvedPickupLocations.ts
+++ b/apps/delivery-options/src/composables/useResolvedPickupLocations.ts
@@ -127,7 +127,13 @@ const callback = (): UseResolvedPickupLocations => {
   });
 
   const locations = addLoadingProperties(
-    computed(() => allLocations.value.sort(sortByDistance)),
+    computed(() => {
+      return allLocations.value
+        .filter((location) =>
+          carriersWithPickup.value.some(({carrier}) => carrier.value.identifier === location.carrier),
+        )
+        .sort(sortByDistance);
+    }),
     currentLocations.load,
     currentLocations.loading,
   );

--- a/libs/shared/src/__tests__/types.ts
+++ b/libs/shared/src/__tests__/types.ts
@@ -1,5 +1,6 @@
 import {type Mock} from 'vitest';
-import {type AbstractEndpoint, type EndpointResponse, type Options} from '@myparcel/sdk';
+import {type PromiseOr} from '@myparcel/ts-utils';
+import {type AbstractEndpoint, type Options, type EndpointResponse} from '@myparcel/sdk';
 import {type CarrierIdentifier, type SupportedPlatformName, type Weekday} from '../types';
 
 export interface MockDeliveryOptionsParameters {
@@ -22,4 +23,6 @@ export interface ExtraDelivery {
   feature: string;
 }
 
-export type SdkMock<E extends AbstractEndpoint> = Mock<[E, Options<E>], EndpointResponse<E>>;
+export type SdkMock<E extends AbstractEndpoint> = Mock<
+  (endpoint: E, options: Options<E>) => PromiseOr<EndpointResponse<E>>
+>;


### PR DESCRIPTION
When having carrier x enabled, loading pickup locations and then removing that carrier from the config, the loaded locations for that carrier would not disappear.
