### PR TITLE
feat: enable time selection and signature/only-recipient for small package type

### DIFF
--- a/apps/delivery-options/src/__snapshots__/index.spec.ts.snap
+++ b/apps/delivery-options/src/__snapshots__/index.spec.ts.snap
@@ -13,6 +13,7 @@ exports[`exports > exports from index.ts 1`] = `
   "CustomDeliveryType",
   "DATES_SHOWN_MD",
   "DATES_SHOWN_SM",
+  "DELIVERY_MOMENT_PACKAGE_TYPES",
   "DISABLE_DELIVERY_OPTIONS",
   "DoButton",
   "EcoFriendlyIcon",

--- a/apps/delivery-options/src/composables/__snapshots__/useDeliveryMomentOptions.spec.ts.snap
+++ b/apps/delivery-options/src/composables/__snapshots__/useDeliveryMomentOptions.spec.ts.snap
@@ -112,31 +112,33 @@ exports[`useDeliveryMomentOptions > returns delivery moment options with package
   {
     "carrier": "postnl",
     "label": {
-      "key": "packageTypePackageSmall",
+      "key": "deliveryStandardTitle",
     },
     "price": 6,
     "value": {
       "carrier": "postnl",
-      "date": null,
       "deliveryType": "standard",
       "packageType": "package_small",
       "shipmentOptions": [],
-      "time": null,
+      "time": {
+        "key": "deliveryStandardTitle",
+      },
     },
   },
   {
     "carrier": "postnl:123",
     "label": {
-      "key": "packageTypePackageSmall",
+      "key": "deliveryStandardTitle",
     },
     "price": 0,
     "value": {
       "carrier": "postnl:123",
-      "date": null,
       "deliveryType": "standard",
       "packageType": "package_small",
       "shipmentOptions": [],
-      "time": null,
+      "time": {
+        "key": "deliveryStandardTitle",
+      },
     },
   },
 ]

--- a/apps/delivery-options/src/composables/__snapshots__/useShipmentOptionsOptions.spec.ts.snap
+++ b/apps/delivery-options/src/composables/__snapshots__/useShipmentOptionsOptions.spec.ts.snap
@@ -1,0 +1,68 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`useShipmentOptionsOptions > should show only the configured options for package type 'digital_stamp' with carrier 'dhlforyou' 1`] = `[]`;
+
+exports[`useShipmentOptionsOptions > should show only the configured options for package type 'digital_stamp' with carrier 'postnl' 1`] = `[]`;
+
+exports[`useShipmentOptionsOptions > should show only the configured options for package type 'mailbox' with carrier 'dhlforyou' 1`] = `[]`;
+
+exports[`useShipmentOptionsOptions > should show only the configured options for package type 'mailbox' with carrier 'postnl' 1`] = `[]`;
+
+exports[`useShipmentOptionsOptions > should show only the configured options for package type 'package' with carrier 'dhlforyou' 1`] = `
+[
+  {
+    "disabled": true,
+    "label": "signatureTitle",
+    "price": 0,
+    "selected": true,
+    "value": "signature",
+  },
+  {
+    "disabled": true,
+    "label": "onlyRecipientTitle",
+    "price": 0,
+    "selected": true,
+    "value": "only_recipient",
+  },
+]
+`;
+
+exports[`useShipmentOptionsOptions > should show only the configured options for package type 'package' with carrier 'postnl' 1`] = `
+[
+  {
+    "disabled": true,
+    "label": "signatureTitle",
+    "price": 0,
+    "selected": true,
+    "value": "signature",
+  },
+  {
+    "disabled": true,
+    "label": "onlyRecipientTitle",
+    "price": 0,
+    "selected": true,
+    "value": "only_recipient",
+  },
+]
+`;
+
+exports[`useShipmentOptionsOptions > should show only the configured options for package type 'package_small' with carrier 'dhlforyou' 1`] = `[]`;
+
+exports[`useShipmentOptionsOptions > should show only the configured options for package type 'package_small' with carrier 'postnl' 1`] = `
+[
+  {
+    "disabled": true,
+    "label": "signatureTitle",
+    "price": 0,
+    "selected": true,
+    "value": "signature",
+  },
+  {
+    "disabled": true,
+    "label": "onlyRecipientTitle",
+    "price": 0,
+    "selected": true,
+    "value": "only_recipient",
+  },
+]
+`;

--- a/apps/delivery-options/src/composables/events/useResolvedValues.ts
+++ b/apps/delivery-options/src/composables/events/useResolvedValues.ts
@@ -29,6 +29,13 @@ const SHIPMENT_OPTION_OUTPUT_MAP = Object.freeze({
   [ShipmentOptionName.OnlyRecipient]: 'onlyRecipient',
 } as Record<SupportedShipmentOptionName, keyof DeliveryOutput['shipmentOptions']>);
 
+/**
+ * Given an array of sipmentOptions, create an object with only the shipmentOptions that are enabled for the carrier.
+ *
+ * @param carrier
+ * @param shipmentOptions
+ * @returns
+ */
 const createResolvedShipmentOptions = (
   carrier: CarrierIdentifier,
   shipmentOptions: string[],

--- a/apps/delivery-options/src/composables/useDeliveryMomentOptions.spec.ts
+++ b/apps/delivery-options/src/composables/useDeliveryMomentOptions.spec.ts
@@ -12,7 +12,7 @@ import {
 import {CarrierName, PackageTypeName} from '@myparcel/constants';
 import {parseJson} from '../utils';
 import {type SelectedDeliveryMoment} from '../types';
-import {useAddressStore, useConfigStore} from '../stores';
+import {useConfigStore} from '../stores';
 import {mockSelectedDeliveryOptions, mockDeliveryOptionsConfig, waitForDeliveryOptions} from '../__tests__';
 import {useDeliveryMomentOptions} from './useDeliveryMomentOptions';
 

--- a/apps/delivery-options/src/composables/useFeatures.ts
+++ b/apps/delivery-options/src/composables/useFeatures.ts
@@ -1,22 +1,22 @@
 import {computed} from 'vue';
 import {useMemoize} from '@vueuse/core';
 import {ConfigSetting} from '@myparcel-do/shared';
-import {PackageTypeName} from '@myparcel/constants';
 import {useConfigStore} from '../stores';
-import {SHOWN_SHIPMENT_OPTIONS} from '../data';
-
-const SUPPORTED_PACKAGE_TYPES = [PackageTypeName.Package, PackageTypeName.PackageSmall];
+import {DELIVERY_MOMENT_PACKAGE_TYPES, SHOWN_SHIPMENT_OPTIONS} from '../data';
 
 export const useFeatures = useMemoize(() => {
   const {state: config} = useConfigStore();
 
   return {
+    /**
+     *  Only a subset of shipment options is available here
+     */
     availableShipmentOptions: computed(() => {
-      return SUPPORTED_PACKAGE_TYPES.includes(config.packageType) ? SHOWN_SHIPMENT_OPTIONS : [];
+      return SHOWN_SHIPMENT_OPTIONS;
     }),
 
     showDeliveryDate: computed(() => {
-      return SUPPORTED_PACKAGE_TYPES.includes(config.packageType) && config[ConfigSetting.ShowDeliveryDate];
+      return DELIVERY_MOMENT_PACKAGE_TYPES.includes(config.packageType) && config[ConfigSetting.ShowDeliveryDate];
     }),
   };
 });

--- a/apps/delivery-options/src/composables/useResolvedCarrier.ts
+++ b/apps/delivery-options/src/composables/useResolvedCarrier.ts
@@ -24,7 +24,9 @@ export type UseResolvedCarrier = {
   deliveryTypes: ComputedRef<Set<SupportedDeliveryTypeName>>;
   disabledDeliveryTypes: Ref<Set<SupportedDeliveryTypeName>>;
   packageTypes: ComputedRef<Set<SupportedPackageTypeName>>;
-  shipmentOptions: ComputedRef<Set<SupportedShipmentOptionName>>;
+  shipmentOptionsPerPackageType: ComputedRef<
+    Partial<Record<SupportedPackageTypeName, Set<SupportedShipmentOptionName>>>
+  >;
   features: ComputedRef<Set<string>>;
   hasDelivery: ComputedRef<boolean>;
   hasFakeDelivery: ComputedRef<boolean>;

--- a/apps/delivery-options/src/composables/useResolvedDeliveryDates.ts
+++ b/apps/delivery-options/src/composables/useResolvedDeliveryDates.ts
@@ -1,11 +1,13 @@
 import {computed, type ComputedRef} from 'vue';
 import {useMemoize} from '@vueuse/core';
 import {type ResolvedDeliveryOptions} from '../types';
+import {useConfigStore} from '../stores';
 import {useResolvedDeliveryOptions} from './useResolvedDeliveryOptions';
 import {useFeatures} from './useFeatures';
 
 export const useResolvedDeliveryDates = useMemoize((): ComputedRef<ResolvedDeliveryOptions[]> => {
   const deliveryOptions = useResolvedDeliveryOptions();
+  const config = useConfigStore();
   const {showDeliveryDate} = useFeatures();
 
   return computed(() => {
@@ -14,6 +16,7 @@ export const useResolvedDeliveryDates = useMemoize((): ComputedRef<ResolvedDeliv
     }
 
     return deliveryOptions.value
+      .filter((option) => option.packageType === config.packageType)
       .reduce((acc, option) => {
         if (option.date && !acc.some((item) => item.date === option.date)) {
           acc.push(option as ResolvedDeliveryOptions);

--- a/apps/delivery-options/src/composables/useResolvedDeliveryDates.ts
+++ b/apps/delivery-options/src/composables/useResolvedDeliveryDates.ts
@@ -7,7 +7,7 @@ import {useFeatures} from './useFeatures';
 
 export const useResolvedDeliveryDates = useMemoize((): ComputedRef<ResolvedDeliveryOptions[]> => {
   const deliveryOptions = useResolvedDeliveryOptions();
-  const config = useConfigStore();
+  const {state: config} = useConfigStore();
   const {showDeliveryDate} = useFeatures();
 
   return computed(() => {

--- a/apps/delivery-options/src/composables/useResolvedDeliveryOptions.spec.ts
+++ b/apps/delivery-options/src/composables/useResolvedDeliveryOptions.spec.ts
@@ -13,6 +13,7 @@ import {
 import {type RecursivePartial} from '@myparcel/ts-utils';
 import {DeliveryTypeName, CarrierName} from '@myparcel/constants';
 import {useAddressStore, useConfigStore} from '../stores';
+import {DELIVERY_MOMENT_PACKAGE_TYPES} from '../data';
 import {
   waitForDeliveryOptions,
   mockDeliveryOptionsConfig,
@@ -175,11 +176,20 @@ describe('useResolvedDeliveryOptions', () => {
     await setupPostNl({[KEY_ADDRESS]: {cc: 'DE'}});
 
     const options = useResolvedDeliveryOptions();
-    const resolvedOptions = options.value.map(({carrier, deliveryType}) => ({carrier, deliveryType}));
+    const resolvedOptions = options.value.map(({carrier, deliveryType, packageType}) => ({
+      carrier,
+      deliveryType,
+      packageType,
+    }));
 
-    expect(resolvedOptions).toEqual([
-      {carrier: CarrierName.PostNl, deliveryType: DeliveryTypeName.Standard},
-      {carrier: CARRIER_IDENTIFIER_WITH_CONTRACT, deliveryType: DeliveryTypeName.Standard},
-    ]);
+    const expected: any[] = [];
+    DELIVERY_MOMENT_PACKAGE_TYPES.forEach((packageType) => {
+      expected.push({carrier: CarrierName.PostNl, deliveryType: DeliveryTypeName.Standard, packageType});
+      expected.push({carrier: CARRIER_IDENTIFIER_WITH_CONTRACT, deliveryType: DeliveryTypeName.Standard, packageType});
+    });
+    // Sort expected by carrier name
+    // eslint-disable-next-line id-length
+    expected.sort((a, b) => a.carrier.localeCompare(b.carrier));
+    expect(resolvedOptions).toEqual(expected);
   });
 });

--- a/apps/delivery-options/src/composables/useResolvedDeliveryOptions.ts
+++ b/apps/delivery-options/src/composables/useResolvedDeliveryOptions.ts
@@ -15,6 +15,7 @@ import {type Timestamp, type DeliveryOption, type DeliveryPossibility, type Deli
 import {DeliveryTypeName} from '@myparcel/constants';
 import {createGetDeliveryOptionsParameters, getResolvedDeliveryType, createDeliveryTypeTranslatable} from '../utils';
 import {type SelectedDeliveryMoment} from '../types';
+import {DELIVERY_MOMENT_PACKAGE_TYPES} from '../data';
 import {useTimeRange} from './useTimeRange';
 import {useActiveCarriers} from './useActiveCarriers';
 
@@ -25,19 +26,20 @@ type FakeDeliveryDates = Replace<
 >;
 
 const createFakeDeliveryDates = (): FakeDeliveryDates[] => {
-  return [
-    {
+  // Create a fake date for each delivery type which uses specfic moments
+  return DELIVERY_MOMENT_PACKAGE_TYPES.map((packageType) => {
+    return {
       date: undefined,
       possibilities: [
         {
           type: DELIVERY_TYPE_DEFAULT,
-          package_type: PACKAGE_TYPE_DEFAULT,
+          package_type: packageType,
           delivery_time_frames: [],
           shipment_options: [],
         },
       ],
-    },
-  ];
+    };
+  });
 };
 
 type UseResolvedDeliveryOptions = ComputedAsync<SelectedDeliveryMoment[]>;

--- a/apps/delivery-options/src/composables/useShipmentOptionsOptions.spec.ts
+++ b/apps/delivery-options/src/composables/useShipmentOptionsOptions.spec.ts
@@ -1,0 +1,101 @@
+import {toValue} from 'vue';
+import {describe, it, expect, beforeEach} from 'vitest';
+import {normalizeDate} from '@vueuse/core';
+import {mockGetDeliveryOptions, getShipmentOptions} from '@myparcel-do/shared/testing';
+import {
+  CarrierSetting,
+  ConfigSetting,
+  createTimestamp,
+  DEFAULT_PLATFORM,
+  KEY_CARRIER_SETTINGS,
+  KEY_CONFIG,
+  type SupportedPackageTypeName,
+} from '@myparcel-do/shared';
+import {CarrierName, PackageTypeName, ShipmentOptionName} from '@myparcel/constants';
+import {getResolvedCarrier} from '../utils';
+import {useConfigStore} from '../stores';
+import {
+  createDeliveryPossibility,
+  getMockDeliveryOptionsConfiguration,
+  mockDeliveryOptionsConfig,
+  waitForDeliveryOptions,
+} from '../__tests__';
+import {useShipmentOptionsOptions} from './useShipmentOptionsOptions';
+import {useSelectedValues} from './useSelectedValues';
+import {useResolvedDeliveryOptions} from './useResolvedDeliveryOptions';
+
+const setup = async (packageType: SupportedPackageTypeName, carrierIdentifier: CarrierName): Promise<void> => {
+  const date = normalizeDate('2022-01-01T15:00:00');
+  mockGetDeliveryOptions.mockReturnValue(
+    Promise.resolve([
+      {
+        carrier: carrierIdentifier,
+        date: createTimestamp(date),
+        possibilities: [
+          createDeliveryPossibility(date, {
+            package_type: packageType,
+            shipment_options: getShipmentOptions([ShipmentOptionName.Signature, ShipmentOptionName.OnlyRecipient]),
+          }),
+        ],
+      },
+    ]),
+  );
+  mockDeliveryOptionsConfig(
+    getMockDeliveryOptionsConfiguration({
+      [KEY_CONFIG]: {
+        [ConfigSetting.ShowDeliveryDate]: true,
+        [CarrierSetting.AllowDeliveryOptions]: true,
+        [CarrierSetting.AllowStandardDelivery]: true,
+        [CarrierSetting.AllowEveningDelivery]: true,
+        [CarrierSetting.AllowMorningDelivery]: true,
+        [CarrierSetting.AllowSignature]: true,
+        [CarrierSetting.AllowOnlyRecipient]: true,
+        [CarrierSetting.PriceStandardDelivery]: 3,
+        [KEY_CARRIER_SETTINGS]: {
+          [carrierIdentifier]: {
+            [CarrierSetting.PricePackageTypePackageSmall]: 6,
+          },
+        },
+        ...(packageType ? {[CarrierSetting.PackageType]: packageType} : {}),
+      },
+    }),
+  );
+  useResolvedDeliveryOptions.clear();
+
+  await waitForDeliveryOptions(carrierIdentifier);
+
+  const moments = useResolvedDeliveryOptions();
+  const momentsForCarrier = moments.value.filter(({carrier}) => carrier === carrierIdentifier);
+  useSelectedValues().deliveryMoment.value = JSON.stringify(momentsForCarrier?.[0]);
+};
+
+describe('useShipmentOptionsOptions', () => {
+  beforeEach(() => {
+    useSelectedValues.clear();
+    useResolvedDeliveryOptions.clear();
+    useConfigStore().reset();
+  });
+
+  it.each([
+    {packageType: PackageTypeName.Package, carrierIdentifier: CarrierName.PostNl},
+    {packageType: PackageTypeName.PackageSmall, carrierIdentifier: CarrierName.PostNl},
+    {packageType: PackageTypeName.DigitalStamp, carrierIdentifier: CarrierName.PostNl},
+    {packageType: PackageTypeName.Mailbox, carrierIdentifier: CarrierName.PostNl},
+    {packageType: PackageTypeName.Package, carrierIdentifier: CarrierName.DhlForYou},
+    {packageType: PackageTypeName.PackageSmall, carrierIdentifier: CarrierName.DhlForYou},
+    {packageType: PackageTypeName.DigitalStamp, carrierIdentifier: CarrierName.DhlForYou},
+    {packageType: PackageTypeName.Mailbox, carrierIdentifier: CarrierName.DhlForYou},
+  ])(
+    'should show only the configured options for package type $packageType with carrier $carrierIdentifier',
+    async ({packageType, carrierIdentifier}) => {
+      await setup(packageType, carrierIdentifier);
+
+      const result = useShipmentOptionsOptions();
+
+      const configuration = getResolvedCarrier(carrierIdentifier, DEFAULT_PLATFORM).shipmentOptionsPerPackageType;
+      const availableOptions = toValue(configuration)[packageType];
+      expect(toValue(result).length).toBe(availableOptions?.size ?? 0);
+      expect(toValue(result)).toMatchSnapshot();
+    },
+  );
+});

--- a/apps/delivery-options/src/composables/useShipmentOptionsOptions.ts
+++ b/apps/delivery-options/src/composables/useShipmentOptionsOptions.ts
@@ -20,18 +20,26 @@ export const useShipmentOptionsOptions = (): ComputedRef<SelectOption[]> => {
 
   return computed(() => {
     const hasNoDeliveryOptions = deliveryOptions.loading.value || !deliveryOptions.value.length;
-    const {carrier, shipmentOptions} = useResolvedCarrier(deliveryMoment.value?.carrier);
+    const {carrier, shipmentOptionsPerPackageType} = useResolvedCarrier(deliveryMoment.value?.carrier);
 
     if (hasNoDeliveryOptions || !carrier.value) {
       return [];
     }
 
-    const carrierShipmentOptions = toValue(shipmentOptions);
     const momentShipmentOptions = toValue(deliveryMoment)?.shipmentOptions;
 
     return availableShipmentOptions.value
       .filter((option) => {
-        return carrierShipmentOptions?.has(option) && momentShipmentOptions?.some(({name}) => name === option);
+        // TODO: create test coverage for this logic
+        const selectedPackageType = toValue(deliveryMoment)?.packageType;
+        const optionsForPackageType = selectedPackageType
+          ? toValue(shipmentOptionsPerPackageType)[selectedPackageType]
+          : undefined;
+
+        // If there is a key for the package type in `shipmentOptionsPerPackageType`, check if the option is available for the package type
+        return optionsForPackageType
+          ? optionsForPackageType.has(option) && momentShipmentOptions?.some(({name}) => name === option)
+          : false;
       })
       .map((name) => {
         const match = momentShipmentOptions?.find((option) => option.name === name);

--- a/apps/delivery-options/src/data/constants.ts
+++ b/apps/delivery-options/src/data/constants.ts
@@ -1,4 +1,4 @@
-import {ShipmentOptionName} from '@myparcel/constants';
+import {PackageTypeName, ShipmentOptionName} from '@myparcel/constants';
 
 /**
  * Stores whether home delivery or pickup is selected.
@@ -33,6 +33,11 @@ export const SHOWN_SHIPMENT_OPTIONS = Object.freeze<ShipmentOptionName[]>([
   ShipmentOptionName.Signature,
   ShipmentOptionName.OnlyRecipient,
 ]);
+
+/**
+ * Enable date/time selection for these package types.
+ */
+export const DELIVERY_MOMENT_PACKAGE_TYPES: PackageTypeName[] = [PackageTypeName.Package, PackageTypeName.PackageSmall];
 
 export const MAP_MARKER_CLASS_ACTIVE = 'active';
 

--- a/apps/delivery-options/src/utils/getResolvedCarrier.spec.ts
+++ b/apps/delivery-options/src/utils/getResolvedCarrier.spec.ts
@@ -90,12 +90,24 @@ describe('getResolvedCarrier', () => {
     );
   });
 
-  it('exposes shipment options, filtered by config', () => {
+  it('exposes shipment options, filtered by what is allowed in config', () => {
     const carrier = getResolvedCarrier(CarrierName.DhlForYou, PlatformName.MyParcel);
 
-    expect(carrier.shipmentOptions.value).toEqual(
-      new Set([ShipmentOptionName.OnlyRecipient, ShipmentOptionName.Signature]),
+    mockDeliveryOptionsConfig(
+      getMockDeliveryOptionsConfiguration({
+        [KEY_CONFIG]: {
+          [KEY_CARRIER_SETTINGS]: {
+            [CarrierName.DhlForYou]: {
+              [CarrierSetting.AllowOnlyRecipient]: true,
+              [CarrierSetting.AllowSignature]: true,
+            },
+          },
+        },
+      }),
     );
+    expect(carrier.shipmentOptionsPerPackageType.value).toEqual({
+      [PackageTypeName.Package]: new Set([ShipmentOptionName.OnlyRecipient, ShipmentOptionName.Signature]),
+    });
 
     mockDeliveryOptionsConfig(
       getMockDeliveryOptionsConfiguration({
@@ -109,7 +121,9 @@ describe('getResolvedCarrier', () => {
       }),
     );
 
-    expect(carrier.shipmentOptions.value).toEqual(new Set([ShipmentOptionName.OnlyRecipient]));
+    expect(carrier.shipmentOptionsPerPackageType.value).toEqual({
+      [PackageTypeName.Package]: new Set([ShipmentOptionName.OnlyRecipient]),
+    });
   });
 
   it('exposes features, filtered by config', () => {

--- a/apps/delivery-options/src/utils/getResolvedCarrier.ts
+++ b/apps/delivery-options/src/utils/getResolvedCarrier.ts
@@ -1,4 +1,4 @@
-import {computed, ref} from 'vue';
+import {computed, ref, toValue} from 'vue';
 import {
   type CarrierIdentifier,
   getConfigKey,
@@ -50,8 +50,12 @@ export const getResolvedCarrier = (
     });
   });
 
-  const shipmentOptions = computed(() => {
-    return filterSet(carrier.shipmentOptions.value, (option) => resolveOption(option, carrierIdentifier));
+  const shipmentOptionsPerPackageType = computed(() => {
+    return Object.fromEntries(
+      Object.entries(toValue(carrier.shipmentOptionsPerPackageType)).map(([packageType, options]) => {
+        return [packageType, filterSet(options, (option) => resolveOption(option, carrierIdentifier))];
+      }),
+    );
   });
 
   const features = computed(() => {
@@ -101,7 +105,7 @@ export const getResolvedCarrier = (
     deliveryCountries: carrier.deliveryCountries,
     deliveryTypes,
     packageTypes: carrier.packageTypes,
-    shipmentOptions,
+    shipmentOptionsPerPackageType,
 
     features,
 

--- a/libs/shared/src/__tests__/mocks/delivery-options/index.ts
+++ b/libs/shared/src/__tests__/mocks/delivery-options/index.ts
@@ -1,3 +1,4 @@
+export * from './entries/getShipmentOptions';
 export * from './findExtraDelivery';
 export * from './getDropOffDay';
 export * from './getNextDeliveryOption';

--- a/libs/shared/src/__tests__/mocks/index.ts
+++ b/libs/shared/src/__tests__/mocks/index.ts
@@ -1,3 +1,4 @@
+export * from './delivery-options';
 export * from './fakeCarriersResponse';
 export * from './fakeDeliveryOptionsResponse';
 export * from './fakePickupLocationsResponse';

--- a/libs/shared/src/config/getMyParcelConfig.ts
+++ b/libs/shared/src/config/getMyParcelConfig.ts
@@ -54,7 +54,10 @@ export const getMyParcelConfig = (): PlatformConfiguration => ({
       pickupCountries: [NETHERLANDS, BELGIUM, DENMARK, SWEDEN, GERMANY],
       smallPackagePickupCountries: [NETHERLANDS, BELGIUM],
       fakeDelivery: true,
-      shipmentOptions: [ShipmentOptionName.OnlyRecipient, ShipmentOptionName.Signature],
+      shipmentOptionsPerPackageType: {
+        [PackageTypeName.Package]: [ShipmentOptionName.OnlyRecipient, ShipmentOptionName.Signature],
+        [PackageTypeName.PackageSmall]: [ShipmentOptionName.OnlyRecipient, ShipmentOptionName.Signature],
+      },
       features: [
         CarrierSetting.DeliveryDaysWindow,
         CarrierSetting.DropOffDays,
@@ -71,7 +74,9 @@ export const getMyParcelConfig = (): PlatformConfiguration => ({
       deliveryCountries: [NETHERLANDS, BELGIUM],
       pickupCountries: [NETHERLANDS, BELGIUM],
       smallPackagePickupCountries: [NETHERLANDS, BELGIUM],
-      shipmentOptions: [ShipmentOptionName.OnlyRecipient, ShipmentOptionName.Signature],
+      shipmentOptionsPerPackageType: {
+        [PackageTypeName.Package]: [ShipmentOptionName.OnlyRecipient, ShipmentOptionName.Signature],
+      },
       features: [CarrierSetting.DeliveryDaysWindow, CarrierSetting.DropOffDays, CarrierSetting.DropOffDelay],
       addressFields: [AddressField.City, AddressField.PostalCode],
     },

--- a/libs/shared/src/config/getSendMyParcelConfig.ts
+++ b/libs/shared/src/config/getSendMyParcelConfig.ts
@@ -42,7 +42,9 @@ export const getSendMyParcelConfig = (): PlatformConfiguration => ({
       pickupCountries: [BELGIUM, NETHERLANDS],
       features: [CarrierSetting.DeliveryDaysWindow, CarrierSetting.DropOffDays, CarrierSetting.DropOffDelay],
       addressFields: [AddressField.PostalCode, AddressField.Street, AddressField.City],
-      shipmentOptions: [ShipmentOptionName.Signature],
+      shipmentOptionsPerPackageType: {
+        [PackageTypeName.Package]: [ShipmentOptionName.Signature],
+      },
       fakeDelivery: true,
       /**
        * API returns a 500 error when package_type is passed, even though it's valid for belgie + bpost.
@@ -56,7 +58,10 @@ export const getSendMyParcelConfig = (): PlatformConfiguration => ({
       deliveryTypes: [DeliveryTypeName.Standard, DeliveryTypeName.Pickup, CustomDeliveryType.Saturday],
       deliveryCountries: [BELGIUM, NETHERLANDS],
       pickupCountries: [BELGIUM, NETHERLANDS],
-      shipmentOptions: [ShipmentOptionName.OnlyRecipient, ShipmentOptionName.Signature],
+      shipmentOptionsPerPackageType: {
+        [PackageTypeName.Package]: [ShipmentOptionName.OnlyRecipient, ShipmentOptionName.Signature],
+        [PackageTypeName.PackageSmall]: [ShipmentOptionName.OnlyRecipient, ShipmentOptionName.Signature],
+      },
       features: [CarrierSetting.DeliveryDaysWindow, CarrierSetting.DropOffDays, CarrierSetting.DropOffDelay],
       fakeDelivery: true,
     },

--- a/libs/shared/src/data/enums.ts
+++ b/libs/shared/src/data/enums.ts
@@ -73,7 +73,7 @@ export enum OptionGroup {
   PackageTypes = 'packageTypes',
   Delivery = 'delivery',
   DeliveryMoments = 'deliveryMoments',
-  ShipmentOptions = 'shipmentOptions',
+  ShipmentOptionsPerPackageType = 'shipmentOptionsPerPackageType',
   Feature = 'feature',
   DropOff = 'dropOff',
   Pickup = 'pickup',

--- a/libs/shared/src/types/platform.types.ts
+++ b/libs/shared/src/types/platform.types.ts
@@ -39,7 +39,10 @@ export interface CarrierConfiguration {
   name: CarrierName;
   packageTypes: SupportedPackageTypeName[];
   pickupCountries?: string[];
-  shipmentOptions?: SupportedShipmentOptionName[];
+  /**
+   * Shipments options that are supported for specific package types.
+   */
+  shipmentOptionsPerPackageType?: Partial<Record<SupportedPackageTypeName, SupportedShipmentOptionName[]>>;
   smallPackagePickupCountries?: string[];
   subscription: SubscriptionType;
   /**

--- a/libs/shared/src/utils/__snapshots__/getPlatformConfig.spec.ts.snap
+++ b/libs/shared/src/utils/__snapshots__/getPlatformConfig.spec.ts.snap
@@ -33,9 +33,11 @@ exports[`getPlatformConfig > gets config for platform belgie 1`] = `
         "BE",
         "NL",
       ],
-      "shipmentOptions": [
-        "signature",
-      ],
+      "shipmentOptionsPerPackageType": {
+        "package": [
+          "signature",
+        ],
+      },
       "subscription": 0,
       "unsupportedParameters": [
         "package_type",
@@ -65,10 +67,16 @@ exports[`getPlatformConfig > gets config for platform belgie 1`] = `
         "BE",
         "NL",
       ],
-      "shipmentOptions": [
-        "only_recipient",
-        "signature",
-      ],
+      "shipmentOptionsPerPackageType": {
+        "package": [
+          "only_recipient",
+          "signature",
+        ],
+        "package_small": [
+          "only_recipient",
+          "signature",
+        ],
+      },
       "subscription": 0,
     },
     {
@@ -184,10 +192,16 @@ exports[`getPlatformConfig > gets config for platform myparcel 1`] = `
         "SE",
         "DE",
       ],
-      "shipmentOptions": [
-        "only_recipient",
-        "signature",
-      ],
+      "shipmentOptionsPerPackageType": {
+        "package": [
+          "only_recipient",
+          "signature",
+        ],
+        "package_small": [
+          "only_recipient",
+          "signature",
+        ],
+      },
       "smallPackagePickupCountries": [
         "NL",
         "BE",
@@ -223,10 +237,12 @@ exports[`getPlatformConfig > gets config for platform myparcel 1`] = `
         "NL",
         "BE",
       ],
-      "shipmentOptions": [
-        "only_recipient",
-        "signature",
-      ],
+      "shipmentOptionsPerPackageType": {
+        "package": [
+          "only_recipient",
+          "signature",
+        ],
+      },
       "smallPackagePickupCountries": [
         "NL",
         "BE",

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,9 @@
+import {defineWorkspace} from 'vitest/config';
+
+export default defineWorkspace([
+  './apps/sandbox/vite.config.ts',
+  './apps/delivery-options/vite-myparcel.config.ts',
+  './apps/delivery-options/vite.config.ts',
+  './apps/delivery-options/vite-myparcel-lib.config.ts',
+  './libs/shared/vite.config.ts',
+]);


### PR DESCRIPTION
Allow configuring different shipment options depending on the package types, in effect enabling only-recipient and signature options for small packages with PostNL. Also enables the time selection and fixes the date selection for small packages.

fixes INT-839, INT-752