### PR TITLE
test(useDateFormat): compare to correct date format

### DIFF
--- a/apps/delivery-options/src/composables/useDateFormat.spec.ts
+++ b/apps/delivery-options/src/composables/useDateFormat.spec.ts
@@ -50,6 +50,8 @@ describe.concurrent('useDateFormat', (it) => {
   it('can parse api date strings', ({expect}) => {
     const formatted = useDateFormat('2021-05-25 14:12:00.000000');
 
-    expect(formatted.date.value).toEqual(new Date('2021-05-25T14:12:00.000Z'));
+    const expected = new Date(2021, 4, 25, 14, 12, 0);
+
+    expect(formatted.date.value).toEqual(expected);
   });
 });


### PR DESCRIPTION
useDateFormat outputs a local time date, which was being compared to a date interpreted as UTC. Changed the test to compare it to the same local time to fix the failing test.