### PR TITLE
fix: display correct translations upon receiving new config

### DIFF
--- a/apps/delivery-options/src/composables/useLanguage.ts
+++ b/apps/delivery-options/src/composables/useLanguage.ts
@@ -15,7 +15,9 @@ interface UseLanguage {
   locale: ComputedRef<string>;
 
   setLocale(locale: string): void;
+
   setStrings(strings: Record<string, string>): void;
+
   translate(translatable: AnyTranslatable): string;
 }
 
@@ -37,7 +39,9 @@ const translate = useMemoize((translatable: AnyTranslatable): string => {
   if (!isDef(translation)) {
     const logger = useLogger();
 
-    if (import.meta.env.DEV) logger.error(`Missing translation: "${resolvedKey}"`);
+    if (import.meta.env.DEV) {
+      logger.error(`Missing translation: "${resolvedKey}"`);
+    }
 
     return resolvedKey;
   }
@@ -76,6 +80,8 @@ export const useLanguage = useMemoize((): UseLanguage => {
 
     setStrings(strings: Record<string, string>): void {
       state.strings = Object.freeze({...strings});
+      // Clear the memoization cache to ensure fresh translations
+      translate.clear();
     },
   } as UseLanguage;
 });


### PR DESCRIPTION
resolves: INT-1006

In the ticket description it suggested to be a reactivity bug, but after some debugging it had to do with some memoization caching, so this is fixed by calling translate.clear();