### PR TITLE
feat: use custom platform from config

### DIFF
--- a/apps/delivery-options/src/config/validateConfiguration.ts
+++ b/apps/delivery-options/src/config/validateConfiguration.ts
@@ -12,7 +12,6 @@ import {
   type InputDeliveryOptionsConfig,
   type InputDeliveryOptionsConfiguration,
   KEY_CARRIER_SETTINGS,
-  SUPPORTED_PLATFORMS,
   validateDropOffDays,
   validateHasMinKeys,
   validateIsBoolean,
@@ -70,7 +69,7 @@ const additionalOptions: ConfigOption[] = [
   {
     key: ConfigSetting.Platform,
     perCarrier: false,
-    validators: [validateIsValue(SUPPORTED_PLATFORMS)],
+    validators: [validateIsString()],
   },
   {
     key: ConfigSetting.ApiBaseUrl,

--- a/libs/shared/src/utils/getCarrierConfiguration.ts
+++ b/libs/shared/src/utils/getCarrierConfiguration.ts
@@ -1,21 +1,12 @@
-import {
-  type CarrierIdentifier,
-  type CarrierConfiguration,
-  type SupportedPlatformName,
-  type PlatformConfiguration,
-} from '../types';
-import {KEY_PLATFORM_CONFIG} from '../data';
+import {type CarrierIdentifier, type CarrierConfiguration, type SupportedPlatformName} from '../types';
+import {usePlatform} from '../composables';
 import {resolveCarrierName} from './resolveCarrierName';
-import {getPlatformConfig} from './getPlatformConfig';
 
 export const getCarrierConfiguration = (
   carrierIdentifier: CarrierIdentifier,
   platform: SupportedPlatformName,
 ): CarrierConfiguration => {
-  const platformConfig = window.MyParcelConfig?.[KEY_PLATFORM_CONFIG]
-    ? (window.MyParcelConfig?.[KEY_PLATFORM_CONFIG] as PlatformConfiguration)
-    : getPlatformConfig(platform);
-
+  const platformConfig = usePlatform(platform).config.value;
   const carrierName = resolveCarrierName(carrierIdentifier);
 
   const carrierConfig = platformConfig.carriers.find((carrier) => carrier.name === carrierName);

--- a/libs/shared/src/utils/getCarrierConfiguration.ts
+++ b/libs/shared/src/utils/getCarrierConfiguration.ts
@@ -1,4 +1,10 @@
-import {type CarrierIdentifier, type CarrierConfiguration, type SupportedPlatformName} from '../types';
+import {
+  type CarrierIdentifier,
+  type CarrierConfiguration,
+  type SupportedPlatformName,
+  type PlatformConfiguration,
+} from '../types';
+import {KEY_PLATFORM_CONFIG} from '../data';
 import {resolveCarrierName} from './resolveCarrierName';
 import {getPlatformConfig} from './getPlatformConfig';
 
@@ -6,7 +12,10 @@ export const getCarrierConfiguration = (
   carrierIdentifier: CarrierIdentifier,
   platform: SupportedPlatformName,
 ): CarrierConfiguration => {
-  const platformConfig = getPlatformConfig(platform);
+  const platformConfig = window.MyParcelConfig?.[KEY_PLATFORM_CONFIG]
+    ? (window.MyParcelConfig?.[KEY_PLATFORM_CONFIG] as PlatformConfiguration)
+    : getPlatformConfig(platform);
+
   const carrierName = resolveCarrierName(carrierIdentifier);
 
   const carrierConfig = platformConfig.carriers.find((carrier) => carrier.name === carrierName);


### PR DESCRIPTION
Resolves: INT-1150

Now uses the usePlatform().config instead of the static getPlatformConfig which always returned netherlands/belgium. This way custom platforms can be passed to the DO