### PR TITLE
fix: resolve proxyCapabilities at fetch time, not at singleton creation

### DIFF
--- a/apps/delivery-options/src/__tests__/utils/mockDeliveryOptionsConfig.ts
+++ b/apps/delivery-options/src/__tests__/utils/mockDeliveryOptionsConfig.ts
@@ -1,6 +1,8 @@
 import {type RecursivePartial} from '@myparcel-dev/ts-utils';
 import {
   CarrierSetting,
+  ConfigSetting,
+  type DeliveryOptionsConfig,
   type DeliveryOptionsConfiguration,
   KEY_CARRIER_SETTINGS,
   KEY_CONFIG,
@@ -10,6 +12,12 @@ import {CarrierName} from '@myparcel-dev/constants';
 import {useAddressStore, useConfigStore} from '../../stores';
 import {validateConfiguration} from '../../config';
 import {getMockDeliveryOptionsConfiguration} from './getMockDeliveryOptionsConfiguration';
+
+// Tests don't supply a real proxyCapabilities URL, but the production guard in
+// useReactiveCapabilitiesRequest skips the fetch when the URL is empty. The
+// vitest global.fetch stub ignores the URL value, so any truthy placeholder is
+// enough to make the capabilities pipeline run during tests.
+const TEST_PROXY_CAPABILITIES_URL = 'https://example.test/proxyCapabilities';
 
 export const mockDeliveryOptionsConfig = <I extends RecursivePartial<DeliveryOptionsConfiguration>>(input?: I): I => {
   const resolvedInput =
@@ -35,7 +43,12 @@ export const mockDeliveryOptionsConfig = <I extends RecursivePartial<DeliveryOpt
     delete validated[KEY_CONFIG][KEY_CARRIER_SETTINGS];
   }
 
-  configStore.update(validated?.[KEY_CONFIG] ?? {}, false);
+  const configUpdate: DeliveryOptionsConfig = {...(validated?.[KEY_CONFIG] ?? {})};
+  if (!configUpdate[ConfigSetting.ProxyCapabilities]) {
+    configUpdate[ConfigSetting.ProxyCapabilities] = TEST_PROXY_CAPABILITIES_URL;
+  }
+
+  configStore.update(configUpdate, false);
   addressStore.update(validated?.[KEY_ADDRESS] ?? {});
 
   return resolvedInput ?? {};

--- a/apps/delivery-options/src/composables/useSharedCapabilities.ts
+++ b/apps/delivery-options/src/composables/useSharedCapabilities.ts
@@ -50,7 +50,11 @@ export const useSharedCapabilities = (): UseCapabilities => {
 
       const apiKeyRef = computed(() => config.apiKey);
 
-      return useReactiveCapabilities(config.proxyCapabilities, requestRef, apiKeyRef);
+      // Pass proxyCapabilities as a getter so the URL is read at fetch time,
+      // not snapshotted now — config may not yet be populated on the first call
+      // (e.g. when useResolvedDeliveryOptions runs in the root's <script setup>
+      // before onMounted/setConfiguration).
+      return useReactiveCapabilities(() => config.proxyCapabilities, requestRef, apiKeyRef);
     })!;
   }
 

--- a/libs/shared/src/composables/sdk/useCapabilitiesRequest.spec.ts
+++ b/libs/shared/src/composables/sdk/useCapabilitiesRequest.spec.ts
@@ -170,4 +170,24 @@ describe('useReactiveCapabilitiesRequest', () => {
 
     expect(loading.value).toBe(false);
   });
+
+  it('skips fetch while proxyCapabilities is empty and fetches once the URL is set', async () => {
+    const urlRef = ref('');
+    const requestRef = ref<CapabilitiesRequest>({recipient: {countryCode: 'NL'}});
+
+    const {loading} = useReactiveCapabilitiesRequest(urlRef, requestRef);
+
+    await flushPromises();
+
+    expect(mockCapabilitiesFetch).not.toHaveBeenCalled();
+    expect(loading.value).toBe(true);
+
+    urlRef.value = PROXY_URL;
+    await nextTick();
+    await flushPromises();
+
+    expect(mockCapabilitiesFetch).toHaveBeenCalledOnce();
+    expect(mockCapabilitiesFetch).toHaveBeenCalledWith(PROXY_URL, expect.any(Object));
+    expect(loading.value).toBe(false);
+  });
 });

--- a/libs/shared/src/composables/sdk/useCapabilitiesRequest.ts
+++ b/libs/shared/src/composables/sdk/useCapabilitiesRequest.ts
@@ -69,8 +69,7 @@ export const useReactiveCapabilitiesRequest = (
     // Skip fetch when URL isn't set yet (e.g. host hasn't pushed config). The
     // watch below re-runs once the URL becomes available.
     if (!url) {
-      loading.value = false;
-      abortController = null;
+      // intentionally keep loading state, for the delivery options will only start working after the url is set
       return;
     }
 

--- a/libs/shared/src/composables/sdk/useCapabilitiesRequest.ts
+++ b/libs/shared/src/composables/sdk/useCapabilitiesRequest.ts
@@ -43,10 +43,16 @@ export interface ReactiveCapabilitiesRequest {
 /**
  * Reactive capabilities request that re-fetches when the request ref changes.
  * Aborts stale in-flight requests. Deduplicates identical requests via JSON comparison.
+ *
+ * `proxyCapabilities` accepts a MaybeRefOrGetter so the URL is resolved at fetch
+ * time, not at construction time. This is essential for hosts that mount the
+ * widget *before* providing the config (e.g. Magento checkout fires the render
+ * event with no detail, then sets `window.MyParcelConfig` later via an update).
+ * Snapshotting the URL would otherwise pin the singleton to an empty string.
  */
 // eslint-disable-next-line max-lines-per-function
 export const useReactiveCapabilitiesRequest = (
-  proxyCapabilities: string,
+  proxyCapabilities: MaybeRefOrGetter<string>,
   requestRef: Ref<CapabilitiesRequest> | ComputedRef<CapabilitiesRequest>,
   apiKey?: MaybeRefOrGetter<string | undefined>,
 ): ReactiveCapabilitiesRequest => {
@@ -58,6 +64,13 @@ export const useReactiveCapabilitiesRequest = (
   const doFetch = async () => {
     const request = toValue(requestRef);
     const currentApiKey = toValue(apiKey);
+    const url = toValue(proxyCapabilities);
+
+    // Skip fetch when URL isn't set yet (e.g. host hasn't pushed config). The
+    // watch below re-runs once the URL becomes available.
+    if (!url) {
+      return;
+    }
 
     if (abortController) {
       abortController.abort();
@@ -67,7 +80,7 @@ export const useReactiveCapabilitiesRequest = (
     loading.value = true;
 
     try {
-      const result = await fetchCapabilities(proxyCapabilities, request, currentApiKey, abortController.signal);
+      const result = await fetchCapabilities(url, request, currentApiKey, abortController.signal);
       const resultJson = JSON.stringify(result);
 
       // Only update when the response actually changed, to avoid triggering downstream watchers
@@ -98,8 +111,10 @@ export const useReactiveCapabilitiesRequest = (
     }
   };
 
-  // Watch a serialized version of the request to avoid false triggers from deep watch
-  const fetchKey = computed(() => JSON.stringify(toValue(requestRef)));
+  // Watch a serialized version of the request *and* the resolved URL to avoid
+  // false triggers from deep watch, while still re-fetching when the URL flips
+  // from empty to a real value.
+  const fetchKey = computed(() => `${toValue(proxyCapabilities)}|${JSON.stringify(toValue(requestRef))}`);
 
   // Initial fetch
   void doFetch();

--- a/libs/shared/src/composables/sdk/useCapabilitiesRequest.ts
+++ b/libs/shared/src/composables/sdk/useCapabilitiesRequest.ts
@@ -69,6 +69,8 @@ export const useReactiveCapabilitiesRequest = (
     // Skip fetch when URL isn't set yet (e.g. host hasn't pushed config). The
     // watch below re-runs once the URL becomes available.
     if (!url) {
+      loading.value = false;
+      abortController = null;
       return;
     }
 

--- a/libs/shared/src/composables/useCapabilities.ts
+++ b/libs/shared/src/composables/useCapabilities.ts
@@ -15,9 +15,12 @@ export const EMPTY_RESPONSE: CapabilitiesResponse = {results: [] as CarrierCapab
 /**
  * Reactive capabilities that re-fetch when the request ref changes.
  * Not memoized — caller is responsible for managing the instance lifecycle.
+ *
+ * `proxyCapabilities` accepts a MaybeRefOrGetter so the URL is resolved per
+ * fetch — see useReactiveCapabilitiesRequest for the rationale.
  */
 export const useReactiveCapabilities = (
-  proxyCapabilities: string,
+  proxyCapabilities: MaybeRefOrGetter<string>,
   requestRef: Ref<CapabilitiesRequest> | ComputedRef<CapabilitiesRequest>,
   apiKey?: MaybeRefOrGetter<string | undefined>,
 ): UseCapabilities => {


### PR DESCRIPTION
The capabilities singleton previously snapshotted `config.proxyCapabilities` when first invoked. When something in the root component setup (e.g. useDeliveryOptionsOutgoingEvents -> useResolvedValues -> useResolvedDeliveryOptions) triggered the singleton before setConfiguration had run, the URL stayed pinned to an empty string for the lifetime of the widget — even after the real URL flowed into the store.

Pass proxyCapabilities as MaybeRefOrGetter end-to-end so it is resolved per fetch. Skip the request when the URL is empty, and include the resolved URL in fetchKey so the watcher re-fires when it flips from '' to a real value.

Surfaced by the Magento checkout, which dispatches the render event without `event.detail` and only applies the config later via an update event.

INT-1291
INT-1670