### PR TITLE
docs: correct Node version and inbound event list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Entry point is `apps/delivery-options/src/main.ts` which calls `bootDeliveryOpti
 
 The widget communicates with the host platform via custom DOM events (`apps/delivery-options/src/data/events.ts`):
 
-- **Inbound**: `myparcel_render_delivery_options`, `myparcel_update_delivery_options`, `myparcel_update_config`, `myparcel_unselect_delivery_options`, `myparcel_disable_delivery_options`, `myparcel_show/hide_delivery_options`
+- **Inbound**: `myparcel_render_delivery_options`, `myparcel_update_delivery_options`, `myparcel_update_config`, `myparcel_unselect_delivery_options`, `myparcel_show_delivery_options`, `myparcel_hide_delivery_options`
 - **Outbound**: `myparcel_updated_delivery_options` (selection changed), `myparcel_updated_address`, `myparcel_error_delivery_options`
 
 ### State Management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Entry point is `apps/delivery-options/src/main.ts` which calls `bootDeliveryOpti
 
 The widget communicates with the host platform via custom DOM events (`apps/delivery-options/src/data/events.ts`):
 
-- **Inbound**: `myparcel_render_delivery_options`, `myparcel_update_delivery_options`, `myparcel_disable_delivery_options`, `myparcel_show/hide_delivery_options`
+- **Inbound**: `myparcel_render_delivery_options`, `myparcel_update_delivery_options`, `myparcel_update_config`, `myparcel_unselect_delivery_options`, `myparcel_disable_delivery_options`, `myparcel_show/hide_delivery_options`
 - **Outbound**: `myparcel_updated_delivery_options` (selection changed), `myparcel_updated_address`, `myparcel_error_delivery_options`
 
 ### State Management

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First read the [Developer Guide for contributing to MyParcel repositories]. Then
 
 ## Pre-requisites
 
-To run this project, you need Node 24 and Yarn. Yarn is bundled with the project, but you need to have (any version) globally to use the `yarn` command.
+To run this project, you need Node 24 and Yarn. If you use Volta, it will automatically install/use the pinned Yarn version from `package.json`.
 
 We recommend using [Volta](https://volta.sh) for Node management. It'll automatically make sure the right version of Node is used within our projects.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First read the [Developer Guide for contributing to MyParcel repositories]. Then
 
 ## Pre-requisites
 
-To run this project, you need Node 20 and Yarn. Yarn is bundled with the project, but you need to have (any version) globally to use the `yarn` command.
+To run this project, you need Node 24 and Yarn. Yarn is bundled with the project, but you need to have (any version) globally to use the `yarn` command.
 
 We recommend using [Volta](https://volta.sh) for Node management. It'll automatically make sure the right version of Node is used within our projects.
 


### PR DESCRIPTION
Small doc corrections surfaced during the capabilities-release documentation pass:

- `CONTRIBUTING.md`: Node 20 → 24 (matches the volta-pinned `node` and CI).
- `CLAUDE.md`: add the two inbound DOM events the widget actually listens for (`myparcel_update_config`, `myparcel_unselect_delivery_options`), verified in `useDeliveryOptionsIncomingEvents.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)