### PR TITLE
fix: keep valid selection when changing address

### DIFF
--- a/apps/delivery-options/src/composables/useResolvedDeliveryOptions.spec.ts
+++ b/apps/delivery-options/src/composables/useResolvedDeliveryOptions.spec.ts
@@ -2,6 +2,7 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import {assign} from 'radash';
 import {normalizeDate} from '@vueuse/core';
 import {flushPromises} from '@vue/test-utils';
+import {waitFor} from '@testing-library/vue';
 import {type RecursivePartial} from '@myparcel-dev/ts-utils';
 import {mockGetDeliveryOptions} from '@myparcel-dev/do-shared/testing';
 import {
@@ -13,7 +14,7 @@ import {
   KEY_ADDRESS,
   ConfigSetting,
 } from '@myparcel-dev/do-shared';
-import {DeliveryTypeName, CarrierName} from '@myparcel-dev/constants';
+import {DeliveryTypeName, CarrierName, PackageTypeName} from '@myparcel-dev/constants';
 import {useConfigStore} from '../stores';
 import {
   waitForDeliveryOptions,
@@ -21,6 +22,7 @@ import {
   getMockDeliveryOptionsConfiguration,
   createDeliveryPossibility,
 } from '../__tests__';
+import {useSelectedValues} from './useSelectedValues';
 import {useResolvedDeliveryOptions} from './useResolvedDeliveryOptions';
 
 const CARRIER_IDENTIFIER_WITH_CONTRACT = `${CarrierName.PostNl}:1234`;
@@ -136,6 +138,55 @@ describe('useResolvedDeliveryOptions', () => {
 
     const options = useResolvedDeliveryOptions();
     expect(options.value).toEqual([]);
+  });
+
+  describe('clearing selected values when no dates are available', () => {
+    // The dates API returns nothing for every carrier, so the resolver yields an empty result.
+    // waitForDeliveryOptions() can't be used here: it waits for request data that never arrives.
+    const setupEmptyResult = async (packageType: PackageTypeName): Promise<void> => {
+      mockGetDeliveryOptions.mockResolvedValue([]);
+
+      mockDeliveryOptionsConfig(
+        getMockDeliveryOptionsConfiguration({
+          [KEY_CONFIG]: {
+            [CarrierSetting.PackageType]: packageType,
+            [CarrierSetting.AllowStandardDelivery]: true,
+            [KEY_CARRIER_SETTINGS]: {
+              [CarrierName.PostNl]: {
+                [CarrierSetting.AllowStandardDelivery]: true,
+              },
+            },
+          },
+        }),
+      );
+
+      useResolvedDeliveryOptions.clear();
+      const options = useResolvedDeliveryOptions();
+      void options.load();
+      // waitFor flushes while polling, letting capabilities + the delivery-options pipeline settle.
+      await waitFor(() => expect(options.loading.value).toBe(false), {timeout: 3000});
+      await flushPromises();
+
+      expect(options.value).toEqual([]);
+    };
+
+    it('does not clear the selection for package types whose options come from another path (mailbox)', async () => {
+      const clearSpy = vi.spyOn(useSelectedValues(), 'clearSelectedValues');
+
+      await setupEmptyResult(PackageTypeName.Mailbox);
+
+      expect(clearSpy).not.toHaveBeenCalled();
+      clearSpy.mockRestore();
+    });
+
+    it('clears the selection for delivery-moment package types when no dates are available', async () => {
+      const clearSpy = vi.spyOn(useSelectedValues(), 'clearSelectedValues');
+
+      await setupEmptyResult(PackageTypeName.Package);
+
+      expect(clearSpy).toHaveBeenCalled();
+      clearSpy.mockRestore();
+    });
   });
 
   describe('Closed Days Filtering', () => {

--- a/apps/delivery-options/src/composables/useResolvedDeliveryOptions.ts
+++ b/apps/delivery-options/src/composables/useResolvedDeliveryOptions.ts
@@ -15,6 +15,8 @@ import {
 } from '@myparcel-dev/do-shared';
 import {createGetDeliveryOptionsParameters, getResolvedDeliveryType, calculateCutoffTime} from '../utils';
 import {type SelectedDeliveryMoment} from '../types';
+import {useConfigStore} from '../stores';
+import {DELIVERY_MOMENT_PACKAGE_TYPES} from '../data';
 import {useTimeRange} from './useTimeRange';
 import {useSharedCapabilities} from './useSharedCapabilities';
 import {useSelectedValues} from './useSelectedValues';
@@ -237,8 +239,13 @@ const removeEmptyEntries = (datesPerCarrier: DeliveryDatesPerCarrier[]): NonNull
   const filteredDates = datesPerCarrier ? datesPerCarrier.filter((item) => item !== null) : [];
 
   if (filteredDates.length === 0) {
-    const {clearSelectedValues} = useSelectedValues();
-    clearSelectedValues();
+    const {state: config} = useConfigStore();
+
+    if (DELIVERY_MOMENT_PACKAGE_TYPES.includes(config.packageType)) {
+      const {clearSelectedValues} = useSelectedValues();
+      clearSelectedValues();
+    }
+
     return [];
   }
 

--- a/apps/delivery-options/src/views/MyParcelDeliveryOptions/Delivery/DeliveryMomentSelector/DeliveryMomentInput.spec.ts
+++ b/apps/delivery-options/src/views/MyParcelDeliveryOptions/Delivery/DeliveryMomentSelector/DeliveryMomentInput.spec.ts
@@ -3,6 +3,7 @@ import {describe, it, expect, beforeEach} from 'vitest';
 import {createPinia, setActivePinia} from 'pinia';
 import {flushPromises} from '@vue/test-utils';
 import {render} from '@testing-library/vue';
+import {CustomEvent} from 'happy-dom';
 import {
   type SelectOption,
   KEY_CONFIG,
@@ -11,8 +12,9 @@ import {
   createUntranslatable,
 } from '@myparcel-dev/do-shared';
 import {CarrierName, DeliveryTypeName, PackageTypeName} from '@myparcel-dev/constants';
-import {useLanguage, useSelectedValues} from '../../../../composables';
+import {useLanguage, useSelectedValues, useDeliveryOptionsIncomingEvents} from '../../../../composables';
 import {mockDeliveryOptionsConfig, getMockDeliveryOptionsConfiguration} from '../../../../__tests__';
+import {UNSELECT_DELIVERY_OPTIONS} from '../../../../data';
 import DeliveryMomentInput from './DeliveryMomentInput.vue';
 
 const makeOption = (
@@ -100,18 +102,22 @@ describe('DeliveryMomentInput.vue', () => {
     expect(deliveryMoment.value).toBe(DHL.value);
   });
 
-  it('re-applies a default when the selection is cleared externally while options exist', async () => {
+  it('keeps the selection cleared after the host fires UNSELECT_DELIVERY_OPTIONS', async () => {
     const {deliveryMoment} = useSelectedValues();
+
+    // Register the real unselect handler, exactly as the app does on boot. It calls
+    // clearSelectedValues() in response to the host's UNSELECT_DELIVERY_OPTIONS event.
+    useDeliveryOptionsIncomingEvents();
 
     renderInput(ref([POSTNL, DHL]));
     await flushPromises();
     expect(deliveryMoment.value).toBe(POSTNL.value);
 
-    // Simulate clearSelectedValues() wiping the selection (e.g. from the delivery-options resolver).
-    deliveryMoment.value = undefined;
+    // The host explicitly clears the selection. It must stay cleared.
+    document.dispatchEvent(new CustomEvent(UNSELECT_DELIVERY_OPTIONS));
     await flushPromises();
 
-    expect(deliveryMoment.value).toBe(POSTNL.value);
+    expect(deliveryMoment.value).toBeUndefined();
   });
 
   it('leaves the selection untouched when there are no options', async () => {

--- a/apps/delivery-options/src/views/MyParcelDeliveryOptions/Delivery/DeliveryMomentSelector/DeliveryMomentInput.spec.ts
+++ b/apps/delivery-options/src/views/MyParcelDeliveryOptions/Delivery/DeliveryMomentSelector/DeliveryMomentInput.spec.ts
@@ -1,0 +1,126 @@
+import {type Ref, defineComponent, h, ref} from 'vue';
+import {describe, it, expect, beforeEach} from 'vitest';
+import {createPinia, setActivePinia} from 'pinia';
+import {flushPromises} from '@vue/test-utils';
+import {render} from '@testing-library/vue';
+import {
+  type SelectOption,
+  KEY_CONFIG,
+  KEY_CARRIER_SETTINGS,
+  CarrierSetting,
+  createUntranslatable,
+} from '@myparcel-dev/do-shared';
+import {CarrierName, DeliveryTypeName, PackageTypeName} from '@myparcel-dev/constants';
+import {useLanguage, useSelectedValues} from '../../../../composables';
+import {mockDeliveryOptionsConfig, getMockDeliveryOptionsConfiguration} from '../../../../__tests__';
+import DeliveryMomentInput from './DeliveryMomentInput.vue';
+
+const makeOption = (
+  carrier: CarrierName,
+  deliveryType: DeliveryTypeName = DeliveryTypeName.Standard,
+): SelectOption<string> => ({
+  carrier,
+  label: createUntranslatable(deliveryType),
+  price: 0,
+  value: JSON.stringify({
+    carrier,
+    date: null,
+    deliveryType,
+    packageType: PackageTypeName.Package,
+    shipmentOptions: [],
+    time: null,
+  }),
+});
+
+const POSTNL = makeOption(CarrierName.PostNl);
+const DHL = makeOption(CarrierName.DhlForYou);
+
+/**
+ * Render DeliveryMomentInput with its v-model bound to the shared `deliveryMoment`, exactly as the
+ * real parent (DeliveryMomentSelector.vue) does. This lets the tests drive/observe the selection
+ * through the shared state the auto-select watch reads and writes.
+ */
+const renderInput = (optionsRef: Ref<SelectOption<string>[]>) => {
+  const {deliveryMoment} = useSelectedValues();
+
+  const Wrapper = defineComponent({
+    setup() {
+      return () =>
+        h(DeliveryMomentInput, {
+          options: optionsRef.value,
+          modelValue: deliveryMoment.value,
+          'onUpdate:modelValue': (value: string | undefined) => {
+            deliveryMoment.value = value;
+          },
+        });
+    },
+  });
+
+  return render(Wrapper);
+};
+
+describe('DeliveryMomentInput.vue', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+
+    const {deliveryMoment, carrier} = useSelectedValues();
+    deliveryMoment.value = undefined;
+    carrier.value = undefined;
+
+    useLanguage().setStrings({});
+
+    mockDeliveryOptionsConfig(
+      getMockDeliveryOptionsConfiguration({
+        [KEY_CONFIG]: {
+          [KEY_CARRIER_SETTINGS]: {
+            [CarrierName.PostNl]: {[CarrierSetting.AllowStandardDelivery]: true},
+            [CarrierName.DhlForYou]: {[CarrierSetting.AllowStandardDelivery]: true},
+          },
+        },
+      }),
+    );
+  });
+
+  it('selects the first standard option by default when nothing is selected', async () => {
+    const {deliveryMoment} = useSelectedValues();
+
+    renderInput(ref([POSTNL, DHL]));
+    await flushPromises();
+
+    expect(deliveryMoment.value).toBe(POSTNL.value);
+  });
+
+  it('preserves a still-valid selection instead of overwriting it with the default', async () => {
+    const {deliveryMoment} = useSelectedValues();
+    deliveryMoment.value = DHL.value;
+
+    renderInput(ref([POSTNL, DHL]));
+    await flushPromises();
+
+    expect(deliveryMoment.value).toBe(DHL.value);
+  });
+
+  it('re-applies a default when the selection is cleared externally while options exist', async () => {
+    const {deliveryMoment} = useSelectedValues();
+
+    renderInput(ref([POSTNL, DHL]));
+    await flushPromises();
+    expect(deliveryMoment.value).toBe(POSTNL.value);
+
+    // Simulate clearSelectedValues() wiping the selection (e.g. from the delivery-options resolver).
+    deliveryMoment.value = undefined;
+    await flushPromises();
+
+    expect(deliveryMoment.value).toBe(POSTNL.value);
+  });
+
+  it('leaves the selection untouched when there are no options', async () => {
+    const {deliveryMoment} = useSelectedValues();
+    deliveryMoment.value = 'stale-value';
+
+    renderInput(ref([]));
+    await flushPromises();
+
+    expect(deliveryMoment.value).toBe('stale-value');
+  });
+});

--- a/apps/delivery-options/src/views/MyParcelDeliveryOptions/Delivery/DeliveryMomentSelector/DeliveryMomentInput.spec.ts
+++ b/apps/delivery-options/src/views/MyParcelDeliveryOptions/Delivery/DeliveryMomentSelector/DeliveryMomentInput.spec.ts
@@ -102,6 +102,16 @@ describe('DeliveryMomentInput.vue', () => {
     expect(deliveryMoment.value).toBe(DHL.value);
   });
 
+  it('replaces a stale selection that is no longer present in the options with the default', async () => {
+    const {deliveryMoment} = useSelectedValues();
+    deliveryMoment.value = 'stale-value';
+
+    renderInput(ref([POSTNL, DHL]));
+    await flushPromises();
+
+    expect(deliveryMoment.value).toBe(POSTNL.value);
+  });
+
   it('keeps the selection cleared after the host fires UNSELECT_DELIVERY_OPTIONS', async () => {
     const {deliveryMoment} = useSelectedValues();
 

--- a/apps/delivery-options/src/views/MyParcelDeliveryOptions/Delivery/DeliveryMomentSelector/DeliveryMomentInput.vue
+++ b/apps/delivery-options/src/views/MyParcelDeliveryOptions/Delivery/DeliveryMomentSelector/DeliveryMomentInput.vue
@@ -68,15 +68,18 @@ const {grouped} = useOptionsGroupedByCarrier(visibleOptions as any);
  * Ensure a valid delivery moment is selected whenever the available options change.
  *
  * Re-applies a default only when the current selection is missing or no longer present in the
- * options (e.g. after an address/package-type change cleared it). A still-valid selection —
- * including a user's manual pick — is preserved. Watching `model` lets the selection self-heal if
- * it gets cleared elsewhere (e.g. by the delivery-options resolver) while options still exist.
+ * newly available options (e.g. after an address/package-type change). A still-valid selection —
+ * including a user's manual pick — is preserved.
+ *
+ * Only the option set and selected date are watched, never `model` itself: an external clear of
+ * the selection (e.g. the host's UNSELECT_DELIVERY_OPTIONS event) must stay cleared rather than
+ * being auto-restored here.
  *
  * Prefers a moment for the pre-selected carrier when one exists, so that compact-view selections
  * survive into the home flow.
  */
 watch(
-  [visibleOptions, deliveryDate, model],
+  [visibleOptions, deliveryDate],
   () => {
     const resolvedOptions = toValue(visibleOptions);
 

--- a/apps/delivery-options/src/views/MyParcelDeliveryOptions/Delivery/DeliveryMomentSelector/DeliveryMomentInput.vue
+++ b/apps/delivery-options/src/views/MyParcelDeliveryOptions/Delivery/DeliveryMomentSelector/DeliveryMomentInput.vue
@@ -65,16 +65,26 @@ const visibleOptions = computed(() => {
 const {grouped} = useOptionsGroupedByCarrier(visibleOptions as any);
 
 /**
- * Automatically select the first standard delivery moment whenever the selected date changes.
- * Prefers a moment for the pre-selected carrier when one exists, so that compact-view
- * selections survive into the home flow.
+ * Ensure a valid delivery moment is selected whenever the available options change.
+ *
+ * Re-applies a default only when the current selection is missing or no longer present in the
+ * options (e.g. after an address/package-type change cleared it). A still-valid selection —
+ * including a user's manual pick — is preserved. Watching `model` lets the selection self-heal if
+ * it gets cleared elsewhere (e.g. by the delivery-options resolver) while options still exist.
+ *
+ * Prefers a moment for the pre-selected carrier when one exists, so that compact-view selections
+ * survive into the home flow.
  */
 watch(
-  [visibleOptions, deliveryDate],
+  [visibleOptions, deliveryDate, model],
   () => {
     const resolvedOptions = toValue(visibleOptions);
 
     if (resolvedOptions.length === 0) {
+      return;
+    }
+
+    if (model.value && resolvedOptions.some((option) => option.value === model.value)) {
       return;
     }
 


### PR DESCRIPTION
I noticed the selection (carrier mainly) was removed when changing addresses in some cases.
This PR fixes that issue twofold:

1) Re-apply a default moment only when the current selection is missing or no longer in the available options, instead of always resetting to the first. A still-valid selection (including a user's manual pick) now survives an address or package-type change, and self-heals if cleared elsewhere.

2) Only clear selected values when the package type actually uses delivery moments.

Note: coverage is 100% (unlike the reported below).

INT-1671
