### PR TITLE
feat: forward business/consumer flag to capabilities so B2B and B2C get the right delivery options

### DIFF
--- a/apps/delivery-options/src/composables/useSharedCapabilities.spec.ts
+++ b/apps/delivery-options/src/composables/useSharedCapabilities.spec.ts
@@ -1,0 +1,76 @@
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+import {flushPromises} from '@vue/test-utils';
+import {AddressField, ConfigSetting, KEY_ADDRESS, KEY_CONFIG} from '@myparcel-dev/do-shared';
+import {useAddressStore, useConfigStore} from '../stores';
+import {mockDeliveryOptionsConfig} from '../__tests__';
+import {resetSharedCapabilities, useSharedCapabilities} from './useSharedCapabilities';
+
+interface CapabilitiesRequestBody {
+  recipient: {
+    countryCode: string;
+    isBusiness?: boolean;
+  };
+}
+
+/**
+ * Read the recipient of the capabilities request that was actually sent. `global.fetch` is
+ * stubbed in the shared vitest setup, so its last call holds the serialized request body.
+ */
+const getLastRequestRecipient = (): CapabilitiesRequestBody['recipient'] => {
+  const {calls} = vi.mocked(fetch).mock;
+  const lastCall = calls.at(-1);
+
+  expect(lastCall).toBeDefined();
+
+  const [, options] = lastCall ?? [];
+  const body = JSON.parse(String(options?.body)) as CapabilitiesRequestBody;
+
+  return body.recipient;
+};
+
+const configureWidget = (isBusiness?: boolean): void => {
+  mockDeliveryOptionsConfig({
+    [KEY_ADDRESS]: {
+      [AddressField.Country]: 'NL',
+    },
+    [KEY_CONFIG]: isBusiness === undefined ? {} : {[ConfigSetting.IsBusiness]: isBusiness},
+  });
+};
+
+describe('useSharedCapabilities', () => {
+  beforeEach(() => {
+    resetSharedCapabilities();
+    useConfigStore().reset();
+    useAddressStore().reset();
+  });
+
+  it('forwards isBusiness=true onto the capabilities recipient for a business shipment', async () => {
+    configureWidget(true);
+
+    useSharedCapabilities();
+    await flushPromises();
+
+    expect(getLastRequestRecipient().isBusiness).toBe(true);
+  });
+
+  it('forwards isBusiness=false onto the capabilities recipient for a consumer shipment', async () => {
+    configureWidget(false);
+
+    useSharedCapabilities();
+    await flushPromises();
+
+    expect(getLastRequestRecipient().isBusiness).toBe(false);
+  });
+
+  it('omits isBusiness when the platform does not provide it, so older hosts keep working', async () => {
+    configureWidget(undefined);
+
+    useSharedCapabilities();
+    await flushPromises();
+
+    const recipient = getLastRequestRecipient();
+
+    expect(recipient.countryCode).toBe('NL');
+    expect(recipient).not.toHaveProperty('isBusiness');
+  });
+});

--- a/apps/delivery-options/src/composables/useSharedCapabilities.ts
+++ b/apps/delivery-options/src/composables/useSharedCapabilities.ts
@@ -36,6 +36,9 @@ export const useSharedCapabilities = (): UseCapabilities => {
           recipient: {
             countryCode: address.cc,
             ...(address.postalCode ? {postalCode: address.postalCode} : {}),
+            // Forward the business flag when the platform sets it (true or false are distinct states
+            // to the API). Omit it entirely when undefined, so hosts that don't send it keep working.
+            ...(config.isBusiness === undefined ? {} : {isBusiness: config.isBusiness}),
           },
         };
 

--- a/apps/delivery-options/src/config/validateConfiguration.ts
+++ b/apps/delivery-options/src/config/validateConfiguration.ts
@@ -111,6 +111,11 @@ const additionalOptions: ConfigOption[] = [
     validators: [validateIsBoolean()],
   },
   {
+    key: ConfigSetting.IsBusiness,
+    perCarrier: false,
+    validators: [validateIsBoolean()],
+  },
+  {
     key: KEY_CARRIER_SETTINGS,
     perCarrier: false,
     validators: [validateIsObject(), validateHasMinKeys(1)],

--- a/apps/sandbox/src/components/SandboxConfiguration.vue
+++ b/apps/sandbox/src/components/SandboxConfiguration.vue
@@ -4,6 +4,8 @@
 
     <SandboxAddressBox />
 
+    <SandboxRecipientTypeBox />
+
     <SandboxPackageTypeBox />
 
     <SandboxCarrierConfigBox />
@@ -14,6 +16,7 @@
 
 <script lang="ts" setup>
 import {useLanguage} from '../composables';
+import SandboxRecipientTypeBox from './SandboxRecipientTypeBox.vue';
 import SandboxPackageTypeBox from './SandboxPackageTypeBox.vue';
 import SandboxFeaturesBox from './SandboxFeaturesBox.vue';
 import SandboxCarrierConfigBox from './SandboxCarrierConfigBox.vue';

--- a/apps/sandbox/src/components/SandboxRecipientTypeBox.spec.ts
+++ b/apps/sandbox/src/components/SandboxRecipientTypeBox.spec.ts
@@ -1,0 +1,86 @@
+import {ref} from 'vue';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {createPinia, setActivePinia} from 'pinia';
+import {fireEvent, render, type RenderResult} from '@testing-library/vue';
+import {useSandboxStore} from '../stores';
+import SandboxRecipientTypeBox from './SandboxRecipientTypeBox.vue';
+
+vi.mock('@vueuse/core', () => {
+  return {
+    useLocalStorage: <T>(_: string, defaultValue: T | (() => T)) => {
+      const resolved = typeof defaultValue === 'function' ? (defaultValue as () => T)() : defaultValue;
+      return ref(resolved);
+    },
+  };
+});
+
+vi.mock('../composables', () => {
+  return {
+    useLanguage: () => ({
+      translate: (translatable: string | {key: string}) =>
+        typeof translatable === 'string' ? translatable : translatable.key,
+    }),
+  };
+});
+
+const NOT_SET = 'Not set';
+const BUSINESS = 'Business (B2B)';
+const CONSUMER = 'Consumer (B2C)';
+
+const renderBox = (isBusiness?: boolean): RenderResult => {
+  const store = useSandboxStore();
+
+  store.config = isBusiness === undefined ? {} : {isBusiness};
+
+  return render(SandboxRecipientTypeBox);
+};
+
+describe('SandboxRecipientTypeBox', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('selects "not set" when the config has no isBusiness', () => {
+    const res = renderBox();
+
+    expect(res.getByLabelText(NOT_SET).checked).toBe(true);
+  });
+
+  it('selects business when isBusiness is true', () => {
+    const res = renderBox(true);
+
+    expect(res.getByLabelText(BUSINESS).checked).toBe(true);
+  });
+
+  it('selects consumer when isBusiness is false', () => {
+    const res = renderBox(false);
+
+    expect(res.getByLabelText(CONSUMER).checked).toBe(true);
+  });
+
+  it('sets isBusiness to true when picking business', async () => {
+    const res = renderBox();
+
+    await fireEvent.update(res.getByLabelText(BUSINESS));
+
+    expect(useSandboxStore().config.isBusiness).toBe(true);
+  });
+
+  it('sets isBusiness to false when picking consumer', async () => {
+    const res = renderBox();
+
+    await fireEvent.update(res.getByLabelText(CONSUMER));
+
+    expect(useSandboxStore().config.isBusiness).toBe(false);
+  });
+
+  it('removes isBusiness from the config when picking "not set"', async () => {
+    const res = renderBox(true);
+
+    await fireEvent.update(res.getByLabelText(NOT_SET));
+
+    // The key has to disappear, not become undefined: the widget only omits it from the
+    // capabilities request when it is absent, which is how hosts that never send it behave.
+    expect('isBusiness' in useSandboxStore().config).toBe(false);
+  });
+});

--- a/apps/sandbox/src/components/SandboxRecipientTypeBox.vue
+++ b/apps/sandbox/src/components/SandboxRecipientTypeBox.vue
@@ -1,0 +1,65 @@
+<template>
+  <Box class="mp-gap-4 mp-grid">
+    <h2 v-text="translate(RECIPIENT_TYPE_LABEL)" />
+
+    <SandboxRadioGroupInput
+      v-model="recipientType"
+      :options="RECIPIENT_TYPE_OPTIONS" />
+  </Box>
+</template>
+
+<script lang="ts" setup>
+import {computed} from 'vue';
+import {type SelectOption} from '@myparcel-dev/do-shared';
+import {useSandboxStore} from '../stores';
+import {useLanguage} from '../composables';
+import {SandboxRadioGroupInput} from './base';
+import {Box} from './Box';
+
+/**
+ * The capabilities API sees business and consumer as two distinct answers, and sending nothing at
+ * all as a third one - that last one is what platforms which don't pass the flag yet look like.
+ * Radio values can only be strings, so they are mapped onto the boolean the config holds.
+ */
+const UNSET = 'unset';
+const BUSINESS = 'business';
+const CONSUMER = 'consumer';
+
+const RECIPIENT_TYPE_LABEL = {key: 'Recipient type', plain: true} as const;
+
+// Labelled in place instead of through a translation key, because the sandbox translations come
+// from an external sheet and this is a developer-only control.
+const RECIPIENT_TYPE_OPTIONS: SelectOption<string>[] = [
+  {label: {key: 'Not set', plain: true}, value: UNSET},
+  {label: {key: 'Business (B2B)', plain: true}, value: BUSINESS},
+  {label: {key: 'Consumer (B2C)', plain: true}, value: CONSUMER},
+];
+
+const sandboxStore = useSandboxStore();
+
+const recipientType = computed({
+  get: () => {
+    const {isBusiness} = sandboxStore.config;
+
+    if (isBusiness === undefined) {
+      return UNSET;
+    }
+
+    return isBusiness ? BUSINESS : CONSUMER;
+  },
+
+  set: (value: string) => {
+    if (value === UNSET) {
+      // Removing the key keeps it out of the config entirely, so the widget omits it from the
+      // request. Setting it to undefined would leave the key behind in the resolved config.
+      delete sandboxStore.config.isBusiness;
+
+      return;
+    }
+
+    sandboxStore.config.isBusiness = value === BUSINESS;
+  },
+});
+
+const {translate} = useLanguage();
+</script>

--- a/apps/sandbox/src/composables/useSandboxCapabilities.spec.ts
+++ b/apps/sandbox/src/composables/useSandboxCapabilities.spec.ts
@@ -1,0 +1,48 @@
+import {ref, type ComputedRef} from 'vue';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {createPinia, setActivePinia} from 'pinia';
+import {type CapabilitiesRequest, useReactiveCapabilities} from '@myparcel-dev/do-shared';
+import {useSandboxStore} from '../stores';
+import {useSandboxCapabilities} from './useSandboxCapabilities';
+
+vi.mock('@myparcel-dev/do-shared', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const original = await importOriginal<typeof import('@myparcel-dev/do-shared')>();
+
+  return {
+    ...original,
+    useReactiveCapabilities: vi.fn(() => ({availableCarrierNames: ref([])})),
+  };
+});
+
+const getRequest = (isBusiness?: boolean): CapabilitiesRequest => {
+  const store = useSandboxStore();
+
+  store.config = isBusiness === undefined ? {} : {isBusiness};
+
+  useSandboxCapabilities();
+
+  const [, request] = vi.mocked(useReactiveCapabilities).mock.calls[0] as [unknown, ComputedRef<CapabilitiesRequest>];
+
+  return request.value;
+};
+
+describe('useSandboxCapabilities', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setActivePinia(createPinia());
+    vi.mocked(useReactiveCapabilities).mockClear();
+  });
+
+  it('leaves isBusiness out of the request when it is not set', () => {
+    expect('isBusiness' in getRequest().recipient).toBe(false);
+  });
+
+  it('sends isBusiness for a business recipient', () => {
+    expect(getRequest(true).recipient.isBusiness).toBe(true);
+  });
+
+  it('sends isBusiness for a consumer recipient', () => {
+    expect(getRequest(false).recipient.isBusiness).toBe(false);
+  });
+});

--- a/apps/sandbox/src/composables/useSandboxCapabilities.ts
+++ b/apps/sandbox/src/composables/useSandboxCapabilities.ts
@@ -17,6 +17,9 @@ export const useSandboxCapabilities = useMemoize(() => {
     return {
       recipient: {
         countryCode: store.address.cc,
+        // Mirrors the widget: forward the flag when it is set, omit it entirely when it is not, so
+        // the carriers listed here match the ones the widget ends up rendering.
+        ...(store.config.isBusiness === undefined ? {} : {isBusiness: store.config.isBusiness}),
       },
       ...(capPackageType ? {packageType: capPackageType} : {}),
     };

--- a/libs/shared/src/data/enums.ts
+++ b/libs/shared/src/data/enums.ts
@@ -53,6 +53,7 @@ export enum ConfigSetting {
   CompactView = 'compactView',
   ExcludeParcelLockers = 'excludeParcelLockers',
   PopUpMap = 'popUpMap',
+  IsBusiness = 'isBusiness',
 }
 
 export enum PickupLocationsView {

--- a/libs/shared/src/types/config.types.ts
+++ b/libs/shared/src/types/config.types.ts
@@ -92,6 +92,13 @@ export interface DeliveryOptionsConfig extends Partial<Record<ConfigSetting, unk
   apiBaseUrl: string;
   proxyCapabilities: string;
   apiKey?: string;
+  /**
+   * Whether the recipient is a business, forwarded onto the capabilities recipient so B2B and B2C
+   * get their correct delivery options. The integrating platform sets it (the PDK derives it from
+   * a company name in the checkout address). Left undefined by hosts that don't send it yet — the
+   * widget then omits it from the request, so older platforms keep working unchanged.
+   */
+  isBusiness?: boolean;
   carrierSettings: CarrierSettingsObject;
   closedDays: Date[];
   /**


### PR DESCRIPTION
The widget now forwards an isBusiness flag from its config onto the capabilities request, so business and consumer checkouts each get their correct delivery options.

The integrating platform sets the flag (the PDK derives it from a company name in the checkout address). true and false are distinct states to the API — business versus a known consumer — and both are forwarded. Hosts that don't send the flag leave it undefined and the widget omits it, so this ships safely over the CDN to older PDK and plugin versions with no change in behavior.

Because it's a pure passthrough of a config boolean, this PR is self-contained and can merge on its own — it doesn't depend on the PDK release that ships the flag.

Follow-up outside this repo: add isBusiness to the config reference on the developer docs site (developer.myparcel.nl).

Fixes INT-1690

🤖 Generated with [Claude Code](https://claude.com/claude-code)