### PR TITLE
fix(sameday): support carriers exposing same-day as a delivery type

### DIFF
--- a/apps/delivery-options/src/__snapshots__/index.spec.ts.snap
+++ b/apps/delivery-options/src/__snapshots__/index.spec.ts.snap
@@ -85,6 +85,8 @@ exports[`exports > exports from index.ts 1`] = `
   "hasDeliveryForCarrier",
   "hasPickupForCarrier",
   "hasSlotContent",
+  "isFallbackEligible",
+  "isSameDayAvailable",
   "padTime",
   "parseJson",
   "resetSharedCapabilities",

--- a/apps/delivery-options/src/__snapshots__/index.spec.ts.snap
+++ b/apps/delivery-options/src/__snapshots__/index.spec.ts.snap
@@ -92,6 +92,7 @@ exports[`exports > exports from index.ts 1`] = `
   "resetSharedCapabilities",
   "showDeveloperInfo",
   "stringToDate",
+  "supportsSameDay",
   "toTime",
   "useActiveCarriers",
   "useAddressStore",

--- a/apps/delivery-options/src/__tests__/utils/__snapshots__/createTestConfiguration.spec.ts.snap
+++ b/apps/delivery-options/src/__tests__/utils/__snapshots__/createTestConfiguration.spec.ts.snap
@@ -583,6 +583,7 @@ exports[`createTestConfiguration > creates a default test configuration with uni
     "compactBackToOverview": "Terug naar overzicht",
     "compactDelivery": "Thuisbezorgen",
     "compactPickup": "Afhalen op locatie",
+    "deliverySameDayTitle": "Vandaag bezorgd",
     "deliveryStandardTitle": "Standaard bezorging",
     "deliveryTitle": "Thuis of op het werk bezorgen",
     "discount": "Korting",

--- a/apps/delivery-options/src/composables/__snapshots__/useDeliveryMomentOptions.spec.ts.snap
+++ b/apps/delivery-options/src/composables/__snapshots__/useDeliveryMomentOptions.spec.ts.snap
@@ -86,7 +86,7 @@ exports[`useDeliveryMomentOptions > returns delivery moment options with package
     "price": 3,
     "value": {
       "carrier": "postnl",
-      "date": "2025-01-15 24:00:00",
+      "date": "2025-01-15 00:00:00",
       "deliveryType": "standard",
       "originalDeliveryType": "standard",
       "packageType": "package",
@@ -128,7 +128,7 @@ exports[`useDeliveryMomentOptions > returns delivery moment options with package
     "price": 456,
     "value": {
       "carrier": "postnl:123",
-      "date": "2025-01-15 24:00:00",
+      "date": "2025-01-15 00:00:00",
       "deliveryType": "standard",
       "originalDeliveryType": "standard",
       "packageType": "package",
@@ -175,7 +175,7 @@ exports[`useDeliveryMomentOptions > returns delivery moment options with package
     "price": 6,
     "value": {
       "carrier": "postnl",
-      "date": "2025-01-15 24:00:00",
+      "date": "2025-01-15 00:00:00",
       "deliveryType": "standard",
       "originalDeliveryType": "standard",
       "packageType": "package_small",
@@ -217,7 +217,7 @@ exports[`useDeliveryMomentOptions > returns delivery moment options with package
     "price": 0,
     "value": {
       "carrier": "postnl:123",
-      "date": "2025-01-15 24:00:00",
+      "date": "2025-01-15 00:00:00",
       "deliveryType": "standard",
       "originalDeliveryType": "standard",
       "packageType": "package_small",

--- a/apps/delivery-options/src/composables/__snapshots__/useDeliveryMomentOptions.spec.ts.snap
+++ b/apps/delivery-options/src/composables/__snapshots__/useDeliveryMomentOptions.spec.ts.snap
@@ -88,6 +88,7 @@ exports[`useDeliveryMomentOptions > returns delivery moment options with package
       "carrier": "postnl",
       "date": "2025-01-15 24:00:00",
       "deliveryType": "standard",
+      "originalDeliveryType": "standard",
       "packageType": "package",
       "shipmentOptions": [
         {
@@ -129,6 +130,7 @@ exports[`useDeliveryMomentOptions > returns delivery moment options with package
       "carrier": "postnl:123",
       "date": "2025-01-15 24:00:00",
       "deliveryType": "standard",
+      "originalDeliveryType": "standard",
       "packageType": "package",
       "shipmentOptions": [
         {
@@ -175,6 +177,7 @@ exports[`useDeliveryMomentOptions > returns delivery moment options with package
       "carrier": "postnl",
       "date": "2025-01-15 24:00:00",
       "deliveryType": "standard",
+      "originalDeliveryType": "standard",
       "packageType": "package_small",
       "shipmentOptions": [
         {
@@ -216,6 +219,7 @@ exports[`useDeliveryMomentOptions > returns delivery moment options with package
       "carrier": "postnl:123",
       "date": "2025-01-15 24:00:00",
       "deliveryType": "standard",
+      "originalDeliveryType": "standard",
       "packageType": "package_small",
       "shipmentOptions": [
         {

--- a/apps/delivery-options/src/composables/events/useResolvedValues.spec.ts
+++ b/apps/delivery-options/src/composables/events/useResolvedValues.spec.ts
@@ -3,6 +3,7 @@ import {flushPromises} from '@vue/test-utils';
 import {
   AddressField,
   CarrierSetting,
+  CustomDeliveryType,
   type DeliveryOptionsOutput,
   type InternalOutput,
   KEY_ADDRESS,
@@ -149,6 +150,78 @@ describe('useResolvedValues', () => {
       expect(resolvedValues.value).toEqual(external);
     },
   );
+
+  it('emits same-day as delivery type for carriers exposing it as a delivery type', async () => {
+    mockDeliveryOptionsConfig({
+      [KEY_CONFIG]: {
+        [CarrierSetting.AllowSameDayDelivery]: true,
+        [CarrierSetting.AllowPriorityDelivery]: false,
+      },
+    });
+
+    mockSelectedDeliveryOptions(
+      createInternalOutput({
+        [FIELD_DELIVERY_DATE]: '2023-12-31',
+        [FIELD_DELIVERY_MOMENT]: {
+          // Trunkrs exposes same-day as a delivery type in its capabilities.
+          carrier: CarrierName.Trunkrs,
+          deliveryType: CustomDeliveryType.SameDay,
+        },
+      }),
+    );
+    await flushPromises();
+
+    const resolvedValues = useResolvedValues();
+
+    expect(resolvedValues.value).toEqual(
+      createExternalOutput({
+        carrier: CarrierName.Trunkrs,
+        date: '2023-12-31',
+        deliveryType: CustomDeliveryType.SameDay,
+        shipmentOptions: {
+          onlyRecipient: false,
+          signature: false,
+        },
+      }),
+    );
+  });
+
+  it('emits same-day as shipment option with the original delivery type for carriers exposing it as an option', async () => {
+    mockDeliveryOptionsConfig({
+      [KEY_CONFIG]: {
+        [CarrierSetting.AllowSameDayDelivery]: true,
+        [CarrierSetting.AllowPriorityDelivery]: false,
+      },
+    });
+
+    mockSelectedDeliveryOptions(
+      createInternalOutput({
+        [FIELD_DELIVERY_DATE]: '2023-12-31',
+        [FIELD_DELIVERY_MOMENT]: {
+          // DHL For You exposes same-day as the sameDayDelivery option in its capabilities.
+          carrier: CarrierName.DhlForYou,
+          deliveryType: CustomDeliveryType.SameDay,
+          originalDeliveryType: DeliveryTypeName.Evening,
+        },
+      }),
+    );
+    await flushPromises();
+
+    const resolvedValues = useResolvedValues();
+
+    expect(resolvedValues.value).toEqual(
+      createExternalOutput({
+        carrier: CarrierName.DhlForYou,
+        date: '2023-12-31',
+        deliveryType: DeliveryTypeName.Evening,
+        shipmentOptions: {
+          onlyRecipient: false,
+          signature: false,
+          sameDayDelivery: true,
+        },
+      }),
+    );
+  });
 
   it('does not expose priorityDelivery outside NL even when selected and enabled', async () => {
     mockDeliveryOptionsConfig({

--- a/apps/delivery-options/src/composables/events/useResolvedValues.ts
+++ b/apps/delivery-options/src/composables/events/useResolvedValues.ts
@@ -1,7 +1,10 @@
-import {computed, type ComputedRef} from 'vue';
+import {computed, toValue, type ComputedRef} from 'vue';
 import {isDef} from '@vueuse/core';
 import {
+  CarrierSetting,
+  CustomDeliveryType,
   SHIPMENT_OPTION_MAP,
+  mapCarrierSettingToCapabilityKeys,
   toCamelCase,
   type DeliveryOutput,
   type PickupOutput,
@@ -15,7 +18,7 @@ import {DeliveryTypeName, ShipmentOptionName} from '@myparcel-dev/constants';
 import {useSelectedValues} from '../useSelectedValues';
 import {useSelectedPickupLocation} from '../useSelectedPickupLocation';
 import {useResolvedDeliveryOptions} from '../useResolvedDeliveryOptions';
-import {getResolvedValue, parseJson} from '../../utils';
+import {getResolvedCarrier, getResolvedValue, parseJson} from '../../utils';
 import {type SelectedDeliveryMomentDelivery} from '../../types';
 import {useAddressStore, useConfigStore} from '../../stores';
 import {FIELD_DELIVERY_MOMENT, FIELD_SHIPMENT_OPTIONS, HOME_OR_PICKUP_PICKUP} from '../../data';
@@ -25,6 +28,49 @@ const DELIVERY_DELIVERY_TYPES = Object.freeze([
   DeliveryTypeName.Evening,
   DeliveryTypeName.Standard,
 ] satisfies SupportedDeliveryTypeName[]);
+
+const isDeliveryDeliveryType = (
+  type: SupportedDeliveryTypeName | DeliveryTypeName,
+): type is DeliveryTypeName.Morning | DeliveryTypeName.Evening | DeliveryTypeName.Standard =>
+  (DELIVERY_DELIVERY_TYPES as readonly string[]).includes(type);
+
+/**
+ * A selected same-day moment is emitted the way the carrier's capabilities
+ * represent it: as the same_day delivery type, or as the sameDayDelivery
+ * shipment option combined with the delivery type the API assigned to the
+ * moment before it was internally resolved to same_day.
+ */
+const resolveOutputDeliveryType = (
+  parsedMoment: SelectedDeliveryMomentDelivery,
+): {deliveryType: DeliveryOutput['deliveryType']; sameDayAsShipmentOption: boolean} => {
+  if (parsedMoment.deliveryType !== CustomDeliveryType.SameDay) {
+    return {
+      deliveryType: isDeliveryDeliveryType(parsedMoment.deliveryType)
+        ? parsedMoment.deliveryType
+        : DeliveryTypeName.Standard,
+      sameDayAsShipmentOption: false,
+    };
+  }
+
+  const capability = toValue(getResolvedCarrier(parsedMoment.carrier).capability);
+  const hasSameDayDeliveryType = mapCarrierSettingToCapabilityKeys(CarrierSetting.AllowSameDayDelivery).some(
+    (entry) => entry.type === 'deliveryType' && Boolean(capability?.deliveryTypes.includes(entry.name)),
+  );
+
+  if (hasSameDayDeliveryType) {
+    return {deliveryType: CustomDeliveryType.SameDay, sameDayAsShipmentOption: false};
+  }
+
+  const {originalDeliveryType} = parsedMoment;
+
+  return {
+    deliveryType:
+      originalDeliveryType && isDeliveryDeliveryType(originalDeliveryType)
+        ? originalDeliveryType
+        : DeliveryTypeName.Standard,
+    sameDayAsShipmentOption: true,
+  };
+};
 
 const SHIPMENT_OPTION_OUTPUT_MAP = Object.freeze(
   Object.fromEntries(Object.values(SHIPMENT_OPTION_MAP).map((sdk) => [sdk, toCamelCase(sdk)])),
@@ -91,9 +137,7 @@ export const useResolvedValues = (): ComputedRef<PickupOutput | DeliveryOutput |
     const parsedMoment = parseJson<SelectedDeliveryMomentDelivery>(selectedValues[FIELD_DELIVERY_MOMENT].value);
     const shipmentOptions = selectedValues[FIELD_SHIPMENT_OPTIONS].value ?? [];
 
-    const deliveryType = DELIVERY_DELIVERY_TYPES.includes(parsedMoment.deliveryType)
-      ? parsedMoment.deliveryType
-      : DeliveryTypeName.Standard;
+    const {deliveryType, sameDayAsShipmentOption} = resolveOutputDeliveryType(parsedMoment);
 
     return {
       carrier: parsedMoment.carrier,
@@ -101,7 +145,10 @@ export const useResolvedValues = (): ComputedRef<PickupOutput | DeliveryOutput |
       deliveryType,
       isPickup: false,
       packageType: parsedMoment.packageType,
-      shipmentOptions: createResolvedShipmentOptions(parsedMoment.carrier, shipmentOptions, address.cc),
+      shipmentOptions: {
+        ...createResolvedShipmentOptions(parsedMoment.carrier, shipmentOptions, address.cc),
+        ...(sameDayAsShipmentOption ? {sameDayDelivery: true} : {}),
+      },
     } satisfies DeliveryOutput;
   });
 };

--- a/apps/delivery-options/src/composables/useDeliveryMomentOptions.spec.ts
+++ b/apps/delivery-options/src/composables/useDeliveryMomentOptions.spec.ts
@@ -336,4 +336,98 @@ describe('useDeliveryMomentOptions', () => {
     expect(fallbackOption?.date).toBeNull();
     expect(fallbackOption?.time).toBeNull();
   });
+
+  it('renders a same-day option in dateless mode for same-day capable carriers before the cutoff', async () => {
+    const options = await setup(PackageTypeName.Package, {
+      [CarrierSetting.DeliveryDaysWindow]: 1,
+      [KEY_CARRIER_SETTINGS]: {
+        [CarrierName.PostNl]: {
+          [CarrierSetting.AllowStandardDelivery]: true,
+        },
+        [CarrierName.Trunkrs]: {
+          [CarrierSetting.AllowSameDayDelivery]: true,
+          [CarrierSetting.CutoffTimeSameDay]: '23:59',
+        },
+      },
+    });
+
+    const resolved = options.value.map((option) => parseJson<SelectedDeliveryMoment>(option.value));
+
+    expect(resolved.some((opt) => opt.carrier === CarrierName.Trunkrs && opt.deliveryType === 'same_day')).toBe(true);
+    expect(resolved.some((opt) => opt.carrier === CarrierName.PostNl && opt.deliveryType === 'standard')).toBe(true);
+  });
+
+  it('does not render a same-day option in dateless mode past the cutoff', async () => {
+    const options = await setup(PackageTypeName.Package, {
+      [CarrierSetting.DeliveryDaysWindow]: 1,
+      [KEY_CARRIER_SETTINGS]: {
+        [CarrierName.PostNl]: {
+          [CarrierSetting.AllowStandardDelivery]: true,
+        },
+        [CarrierName.Trunkrs]: {
+          [CarrierSetting.AllowSameDayDelivery]: true,
+          [CarrierSetting.CutoffTimeSameDay]: '00:00',
+        },
+      },
+    });
+
+    const carriers = options.value.map((option) => parseJson<SelectedDeliveryMoment>(option.value).carrier);
+
+    expect(carriers).not.toContain(CarrierName.Trunkrs);
+  });
+
+  it('does not show a standard fallback for carriers that do not support standard delivery', async () => {
+    const options = await setup(
+      PackageTypeName.Package,
+      {
+        [KEY_CARRIER_SETTINGS]: {
+          [CarrierName.PostNl]: {
+            [CarrierSetting.AllowStandardDelivery]: true,
+          },
+          [CarrierName.UpsExpressSaver]: {
+            [CarrierSetting.AllowExpressDelivery]: true,
+          },
+        },
+      },
+      createFallbackMock(MOCK_DATE),
+    );
+
+    const carriers = options.value.map((option) => parseJson<SelectedDeliveryMoment>(option.value).carrier);
+
+    expect(carriers).toContain(CarrierName.PostNl);
+    expect(carriers).not.toContain(CarrierName.UpsExpressSaver);
+  });
+
+  it('shows a synthesized same-day option for a same-day-only carrier when today is selected', async () => {
+    const options = await setup(
+      PackageTypeName.Package,
+      {
+        [KEY_CARRIER_SETTINGS]: {
+          [CarrierName.PostNl]: {
+            [CarrierSetting.AllowStandardDelivery]: true,
+          },
+          [CarrierName.Trunkrs]: {
+            [CarrierSetting.AllowSameDayDelivery]: true,
+            [CarrierSetting.CutoffTimeSameDay]: '23:59',
+          },
+        },
+      },
+      createFallbackMock(MOCK_DATE),
+    );
+
+    const resolvedOptions = useResolvedDeliveryOptions();
+    const sameDayMoment = resolvedOptions.value.find((opt) => opt.carrier === CarrierName.Trunkrs);
+
+    expect(sameDayMoment?.date).toBeTruthy();
+
+    const {deliveryDate} = useSelectedValues();
+    deliveryDate.value = sameDayMoment?.date ?? '';
+    await flushPromises();
+
+    const resolved = options.value.map((option) => parseJson<SelectedDeliveryMoment>(option.value));
+
+    expect(resolved.some((opt) => opt.carrier === CarrierName.Trunkrs && opt.deliveryType === 'same_day')).toBe(true);
+    // PostNL has no moments for today and gets no standard fallback either (selected date is today).
+    expect(resolved.some((opt) => opt.carrier === CarrierName.PostNl)).toBe(false);
+  });
 });

--- a/apps/delivery-options/src/composables/useDeliveryMomentOptions.spec.ts
+++ b/apps/delivery-options/src/composables/useDeliveryMomentOptions.spec.ts
@@ -357,7 +357,7 @@ describe('useDeliveryMomentOptions', () => {
     expect(resolved.some((opt) => opt.carrier === CarrierName.PostNl && opt.deliveryType === 'standard')).toBe(true);
   });
 
-  it('does not render a same-day option in dateless mode past the cutoff', async () => {
+  it('renders a same-day option in dateless mode past the cutoff', async () => {
     const options = await setup(PackageTypeName.Package, {
       [CarrierSetting.DeliveryDaysWindow]: 1,
       [KEY_CARRIER_SETTINGS]: {
@@ -373,7 +373,7 @@ describe('useDeliveryMomentOptions', () => {
 
     const carriers = options.value.map((option) => parseJson<SelectedDeliveryMoment>(option.value).carrier);
 
-    expect(carriers).not.toContain(CarrierName.Trunkrs);
+    expect(carriers).toContain(CarrierName.Trunkrs);
   });
 
   it('does not show a standard fallback for carriers that do not support standard delivery', async () => {
@@ -425,9 +425,101 @@ describe('useDeliveryMomentOptions', () => {
     await flushPromises();
 
     const resolved = options.value.map((option) => parseJson<SelectedDeliveryMoment>(option.value));
+    const trunkrsOptions = resolved.filter((opt) => opt.carrier === CarrierName.Trunkrs);
 
-    expect(resolved.some((opt) => opt.carrier === CarrierName.Trunkrs && opt.deliveryType === 'same_day')).toBe(true);
+    // Exactly one option: the synthetic today-moment, without a duplicate dateless fallback.
+    expect(trunkrsOptions).toHaveLength(1);
+    expect(trunkrsOptions[0].deliveryType).toBe('same_day');
+    // Synthetic moments are not backed by an API response, so the selectable
+    // value must never promise a delivery date.
+    expect(trunkrsOptions[0].date).toBeNull();
     // PostNL has no moments for today and gets no standard fallback either (selected date is today).
     expect(resolved.some((opt) => opt.carrier === CarrierName.PostNl)).toBe(false);
+  });
+
+  it('shows a dateless same-day fallback on a future date, regardless of the cutoff', async () => {
+    const options = await setup(
+      PackageTypeName.Package,
+      {
+        [KEY_CARRIER_SETTINGS]: {
+          [CarrierName.PostNl]: {
+            [CarrierSetting.AllowStandardDelivery]: true,
+          },
+          [CarrierName.Trunkrs]: {
+            [CarrierSetting.AllowSameDayDelivery]: true,
+            [CarrierSetting.CutoffTimeSameDay]: '00:00',
+          },
+        },
+      },
+      createFallbackMock(MOCK_DATE),
+    );
+
+    const resolved = options.value.map((option) => parseJson<SelectedDeliveryMoment>(option.value));
+    const trunkrsOption = resolved.find((opt) => opt.carrier === CarrierName.Trunkrs);
+
+    expect(trunkrsOption?.deliveryType).toBe('same_day');
+    expect(trunkrsOption?.date).toBeNull();
+  });
+
+  it('shows nothing for a same-day fallback carrier on today past the cutoff', async () => {
+    mockStringToDateResult.value = new Date();
+
+    const options = await setup(
+      PackageTypeName.Package,
+      {
+        [KEY_CARRIER_SETTINGS]: {
+          [CarrierName.PostNl]: {
+            [CarrierSetting.AllowStandardDelivery]: true,
+          },
+          [CarrierName.Trunkrs]: {
+            [CarrierSetting.AllowSameDayDelivery]: true,
+            [CarrierSetting.CutoffTimeSameDay]: '00:00',
+          },
+        },
+      },
+      createFallbackMock(MOCK_DATE),
+    );
+
+    const carriers = options.value.map((option) => parseJson<SelectedDeliveryMoment>(option.value).carrier);
+
+    expect(carriers).not.toContain(CarrierName.Trunkrs);
+  });
+
+  it('shows a plain dateless list including same-day when no carrier got API dates', async () => {
+    // setup() cannot be used here: waitForDeliveryOptions awaits load(), which
+    // only resolves once at least one moment exists, and this scenario has none.
+    mockGetDeliveryOptions.mockResolvedValue([]);
+
+    mockDeliveryOptionsConfig(
+      getMockDeliveryOptionsConfiguration({
+        [KEY_CONFIG]: {
+          [CarrierSetting.PackageType]: PackageTypeName.Package,
+          [KEY_CARRIER_SETTINGS]: {
+            [CarrierName.PostNl]: {
+              [CarrierSetting.AllowStandardDelivery]: true,
+            },
+            [CarrierName.Trunkrs]: {
+              [CarrierSetting.AllowSameDayDelivery]: true,
+              [CarrierSetting.CutoffTimeSameDay]: '00:00',
+            },
+          },
+        },
+      }),
+    );
+    mockSelectedDeliveryOptions();
+
+    const options = useDeliveryMomentOptions();
+
+    useResolvedDeliveryOptions.clear();
+    const deliveryOptions = useResolvedDeliveryOptions();
+    void deliveryOptions.load();
+    await waitFor(() => expect(deliveryOptions.loading.value).toBe(false), {timeout: 3000});
+    await flushPromises();
+
+    const resolved = options.value.map((option) => parseJson<SelectedDeliveryMoment>(option.value));
+
+    expect(resolved.some((opt) => opt.carrier === CarrierName.PostNl && opt.deliveryType === 'standard')).toBe(true);
+    expect(resolved.some((opt) => opt.carrier === CarrierName.Trunkrs && opt.deliveryType === 'same_day')).toBe(true);
+    expect(resolved.every((opt) => opt.date === null)).toBe(true);
   });
 });

--- a/apps/delivery-options/src/composables/useDeliveryMomentOptions.spec.ts
+++ b/apps/delivery-options/src/composables/useDeliveryMomentOptions.spec.ts
@@ -204,8 +204,9 @@ describe('useDeliveryMomentOptions', () => {
 
     const parsed = options.value.map((option) => parseJson<SelectedDeliveryMoment>(option.value));
 
-    // window=0 means "no date": each carrier shows a single dateless (fake) option.
-    expect(parsed).toHaveLength(2);
+    // window=0 means "no date": each carrier shows a dateless (fake) option.
+    // DhlForYou also offers same-day (sameDayDelivery capability), so it gets two.
+    expect(parsed).toHaveLength(3);
     expect(parsed.every((opt) => opt.date === null && opt.time === null)).toBe(true);
   });
 

--- a/apps/delivery-options/src/composables/useDeliveryMomentOptions.ts
+++ b/apps/delivery-options/src/composables/useDeliveryMomentOptions.ts
@@ -7,7 +7,9 @@ import {
   type SelectOption,
   type SupportedDeliveryTypeName,
   type SupportedPackageTypeName,
+  CarrierSetting,
   CustomDeliveryType,
+  DELIVERY_DAYS_WINDOW_DEFAULT,
   DELIVERY_TYPE_DEFAULT,
   SUPPORTED_SHIPMENT_OPTIONS,
   createTranslatable,
@@ -151,6 +153,25 @@ const getDatelessDeliveryOptions = (
 };
 
 /**
+ * Dateless options for carriers whose own delivery-days window is 0. They never get
+ * dates from the API, so they show up next to the dated carriers - the same behaviour
+ * as a global window of 0, just applied per carrier. Carriers with a window of 1 or
+ * more are handled through their API delivery moments instead, so they are skipped.
+ */
+const getWindowZeroDatelessOptions = (
+  carriers: UseResolvedCarrier[],
+  packageType: SupportedPackageTypeName,
+): SelectOption<string>[] => {
+  return carriers
+    .filter(
+      (carrier) =>
+        toValue(carrier.hasDelivery) &&
+        carrier.get(CarrierSetting.DeliveryDaysWindow, DELIVERY_DAYS_WINDOW_DEFAULT) === 0,
+    )
+    .flatMap((carrier) => createCarrierDatelessOptions(carrier, packageType));
+};
+
+/**
  * Fallback options for carriers that have no real API delivery moments on any
  * date. Skipped when the selected date is today: a dateless standard delivery
  * cannot arrive today, and same-day on today is covered by the synthetic
@@ -186,10 +207,7 @@ export const useDeliveryMomentOptions = (): ComputedRef<SelectOption<string>[]> 
       return getDatelessDeliveryOptions(activeCarriers.value, config.packageType);
     }
 
-    // Carriers with a delivery-days window of 0 never have dates, so show them as a single
-    // dateless "fake" option next to the dated carriers - the same behaviour as a global
-    // window of 0, just applied per carrier.
-    const datelessOptions = getDatelessDeliveryOptions(activeCarriers.value, config.packageType);
+    const datelessOptions = getWindowZeroDatelessOptions(activeCarriers.value, config.packageType);
 
     const momentOptions = getMomentOptions(deliveryMoments.value, config.packageType);
 

--- a/apps/delivery-options/src/composables/useDeliveryMomentOptions.ts
+++ b/apps/delivery-options/src/composables/useDeliveryMomentOptions.ts
@@ -17,7 +17,7 @@ import {
   createPackageTypeTranslatable,
   stringToDate,
   isFallbackEligible,
-  isSameDayAvailable,
+  supportsSameDay,
 } from '../utils';
 import {type SelectedDeliveryMoment} from '../types';
 import {useConfigStore} from '../stores';
@@ -87,7 +87,10 @@ const getMomentOptions = (
       value: JSON.stringify({
         time: option.time,
         carrier: option.carrier,
-        date: option.date,
+        // A synthetic moment's date only extends the date picker; it is not
+        // backed by an API response, so the selectable value must never
+        // promise a delivery date.
+        date: option.isSynthetic ? null : option.date,
         deliveryType: option.deliveryType,
         originalDeliveryType: option.originalDeliveryType,
         packageType: option.packageType,
@@ -98,57 +101,65 @@ const getMomentOptions = (
     }));
 
 /**
- * Options when the delivery date is hidden (deliveryDaysWindow = 0): a generic
- * "standard delivery" option per carrier supporting it, plus a same-day option
- * for carriers where same-day is currently available.
+ * The dateless options a carrier can offer: a generic standard delivery
+ * option, and a same-day option. Same-day means shipped on the day of
+ * delivery, so it is plannable for any day; the cutoff time only gates
+ * delivery on today itself, which is handled by the synthetic today moment.
+ */
+const createCarrierDatelessOptions = (
+  carrier: UseResolvedCarrier,
+  packageType: SupportedPackageTypeName,
+): SelectOption<string>[] => {
+  const {identifier} = toValue(carrier.carrier);
+  const options: SelectOption<string>[] = [];
+
+  if (toValue(carrier.deliveryTypes).has(DELIVERY_TYPE_DEFAULT)) {
+    options.push(
+      createDatelessDeliveryOption(
+        identifier,
+        createTranslatable(`delivery${pascal(DELIVERY_TYPE_DEFAULT)}Title`),
+        packageType,
+      ),
+    );
+  }
+
+  if (supportsSameDay(carrier)) {
+    options.push(
+      createDatelessDeliveryOption(
+        identifier,
+        createTranslatable(`delivery${pascal(CustomDeliveryType.SameDay)}Title`),
+        packageType,
+        CustomDeliveryType.SameDay,
+      ),
+    );
+  }
+
+  return options;
+};
+
+/**
+ * Options when the delivery date is hidden (deliveryDaysWindow <= 1): the
+ * dateless options per carrier supporting delivery.
  */
 const getDatelessDeliveryOptions = (
   carriers: UseResolvedCarrier[],
   packageType: SupportedPackageTypeName,
 ): SelectOption<string>[] => {
   return carriers
-    .filter(
-      (carrier) =>
-        toValue(carrier.hasDelivery) &&
-        carrier.get(CarrierSetting.DeliveryDaysWindow, DELIVERY_DAYS_WINDOW_DEFAULT) === 0,
-    )
-    .flatMap((carrier) => {
-      const {identifier} = toValue(carrier.carrier);
-      const options: SelectOption<string>[] = [];
-
-      if (toValue(carrier.deliveryTypes).has(DELIVERY_TYPE_DEFAULT)) {
-        options.push(
-          createDatelessDeliveryOption(
-            identifier,
-            createTranslatable(`delivery${pascal(DELIVERY_TYPE_DEFAULT)}Title`),
-            packageType,
-          ),
-        );
-      }
-
-      if (isSameDayAvailable(carrier)) {
-        options.push(
-          createDatelessDeliveryOption(
-            identifier,
-            createTranslatable(`delivery${pascal(CustomDeliveryType.SameDay)}Title`),
-            packageType,
-            CustomDeliveryType.SameDay,
-          ),
-        );
-      }
-
-      return options;
-    });
+    .filter((carrier) => toValue(carrier.hasDelivery))
+    .flatMap((carrier) => createCarrierDatelessOptions(carrier, packageType));
 };
 
 /**
- * Fallback options for carriers that have no API delivery moments on any date.
- * Skipped when the selected date is today (no same-day fallback).
+ * Fallback options for carriers that have no real API delivery moments on any
+ * date. Skipped when the selected date is today: a dateless standard delivery
+ * cannot arrive today, and same-day on today is covered by the synthetic
+ * today moment while its cutoff has not passed.
  */
 const getFallbackCarrierOptions = (
   carriers: UseResolvedCarrier[],
   packageType: SupportedPackageTypeName,
-  carriersWithAnyMoments: Set<CarrierIdentifier>,
+  carriersWithRealMoments: Set<CarrierIdentifier>,
   selectedDateIsToday: boolean,
 ): SelectOption<string>[] => {
   if (selectedDateIsToday) {
@@ -156,21 +167,8 @@ const getFallbackCarrierOptions = (
   }
 
   return carriers
-    .filter((carrier) => {
-      // The fallback claims a standard delivery, so the carrier must actually
-      // support standard delivery and have it enabled (e.g. a same-day-only
-      // carrier like Trunkrs must not get a standard fallback).
-      return (
-        isFallbackEligible(carrier, carriersWithAnyMoments) && toValue(carrier.deliveryTypes).has(DELIVERY_TYPE_DEFAULT)
-      );
-    })
-    .map((carrier) => {
-      return createDatelessDeliveryOption(
-        toValue(carrier.carrier).identifier,
-        createTranslatable(`delivery${pascal(DELIVERY_TYPE_DEFAULT)}Title`),
-        packageType,
-      );
-    });
+    .filter((carrier) => isFallbackEligible(carrier, carriersWithRealMoments))
+    .flatMap((carrier) => createCarrierDatelessOptions(carrier, packageType));
 };
 
 export const useDeliveryMomentOptions = (): ComputedRef<SelectOption<string>[]> => {
@@ -199,14 +197,16 @@ export const useDeliveryMomentOptions = (): ComputedRef<SelectOption<string>[]> 
     const {deliveryDate} = useSelectedValues();
     const selectedDateIsToday = Boolean(deliveryDate.value && isToday(stringToDate(deliveryDate.value)));
 
-    const carriersWithAnyMoments = new Set(
-      allDeliveryOptions.value.filter((opt) => opt.packageType === config.packageType).map((opt) => opt.carrier),
+    const carriersWithRealMoments = new Set(
+      allDeliveryOptions.value
+        .filter((opt) => !opt.isSynthetic && opt.packageType === config.packageType)
+        .map((opt) => opt.carrier),
     );
 
     const fallbackOptions = getFallbackCarrierOptions(
       activeCarriers.value,
       config.packageType,
-      carriersWithAnyMoments,
+      carriersWithRealMoments,
       selectedDateIsToday,
     );
 

--- a/apps/delivery-options/src/composables/useDeliveryMomentOptions.ts
+++ b/apps/delivery-options/src/composables/useDeliveryMomentOptions.ts
@@ -5,14 +5,20 @@ import {
   type AnyTranslatable,
   type CarrierIdentifier,
   type SelectOption,
+  type SupportedDeliveryTypeName,
   type SupportedPackageTypeName,
+  CustomDeliveryType,
   DELIVERY_TYPE_DEFAULT,
-  CarrierSetting,
-  DELIVERY_DAYS_WINDOW_DEFAULT,
   SUPPORTED_SHIPMENT_OPTIONS,
   createTranslatable,
 } from '@myparcel-dev/do-shared';
-import {getDeliveryTypePrice, createPackageTypeTranslatable, stringToDate} from '../utils';
+import {
+  getDeliveryTypePrice,
+  createPackageTypeTranslatable,
+  stringToDate,
+  isFallbackEligible,
+  isSameDayAvailable,
+} from '../utils';
 import {type SelectedDeliveryMoment} from '../types';
 import {useConfigStore} from '../stores';
 import {DELIVERY_MOMENT_PACKAGE_TYPES} from '../data';
@@ -31,14 +37,15 @@ const createDatelessDeliveryOption = (
   carrierIdentifier: CarrierIdentifier,
   label: AnyTranslatable,
   packageType: SupportedPackageTypeName,
+  deliveryType: SupportedDeliveryTypeName = DELIVERY_TYPE_DEFAULT,
 ): SelectOption<string> => ({
   carrier: carrierIdentifier,
   label,
-  price: getDeliveryTypePrice(DELIVERY_TYPE_DEFAULT, carrierIdentifier),
+  price: getDeliveryTypePrice(deliveryType, carrierIdentifier),
   value: JSON.stringify({
     carrier: carrierIdentifier,
     date: null,
-    deliveryType: DELIVERY_TYPE_DEFAULT,
+    deliveryType,
     packageType,
     shipmentOptions: [],
     time: null,
@@ -82,6 +89,7 @@ const getMomentOptions = (
         carrier: option.carrier,
         date: option.date,
         deliveryType: option.deliveryType,
+        originalDeliveryType: option.originalDeliveryType,
         packageType: option.packageType,
         shipmentOptions: option.shipmentOptions.filter((opt) =>
           (SUPPORTED_SHIPMENT_OPTIONS as readonly string[]).includes(opt.name),
@@ -90,9 +98,9 @@ const getMomentOptions = (
     }));
 
 /**
- * Dateless "fake" options for carriers with a delivery-days window of 0: the carrier shows
- * up without a date or time. Carriers with a window of 1 or more are handled through their
- * API delivery moments instead, so they are skipped here.
+ * Options when the delivery date is hidden (deliveryDaysWindow = 0): a generic
+ * "standard delivery" option per carrier supporting it, plus a same-day option
+ * for carriers where same-day is currently available.
  */
 const getDatelessDeliveryOptions = (
   carriers: UseResolvedCarrier[],
@@ -104,12 +112,32 @@ const getDatelessDeliveryOptions = (
         toValue(carrier.hasDelivery) &&
         carrier.get(CarrierSetting.DeliveryDaysWindow, DELIVERY_DAYS_WINDOW_DEFAULT) === 0,
     )
-    .map((carrier) => {
-      return createDatelessDeliveryOption(
-        toValue(carrier.carrier).identifier,
-        createTranslatable(`delivery${pascal(DELIVERY_TYPE_DEFAULT)}Title`),
-        packageType,
-      );
+    .flatMap((carrier) => {
+      const {identifier} = toValue(carrier.carrier);
+      const options: SelectOption<string>[] = [];
+
+      if (toValue(carrier.deliveryTypes).has(DELIVERY_TYPE_DEFAULT)) {
+        options.push(
+          createDatelessDeliveryOption(
+            identifier,
+            createTranslatable(`delivery${pascal(DELIVERY_TYPE_DEFAULT)}Title`),
+            packageType,
+          ),
+        );
+      }
+
+      if (isSameDayAvailable(carrier)) {
+        options.push(
+          createDatelessDeliveryOption(
+            identifier,
+            createTranslatable(`delivery${pascal(CustomDeliveryType.SameDay)}Title`),
+            packageType,
+            CustomDeliveryType.SameDay,
+          ),
+        );
+      }
+
+      return options;
     });
 };
 
@@ -129,15 +157,12 @@ const getFallbackCarrierOptions = (
 
   return carriers
     .filter((carrier) => {
-      const id = toValue(carrier.carrier).identifier;
-
-      if (carriersWithAnyMoments.has(id)) return false;
-
-      if (!toValue(carrier.hasDelivery)) return false;
-
-      const deliveryDaysWindow = carrier.get(CarrierSetting.DeliveryDaysWindow, DELIVERY_DAYS_WINDOW_DEFAULT);
-
-      return deliveryDaysWindow !== 0;
+      // The fallback claims a standard delivery, so the carrier must actually
+      // support standard delivery and have it enabled (e.g. a same-day-only
+      // carrier like Trunkrs must not get a standard fallback).
+      return (
+        isFallbackEligible(carrier, carriersWithAnyMoments) && toValue(carrier.deliveryTypes).has(DELIVERY_TYPE_DEFAULT)
+      );
     })
     .map((carrier) => {
       return createDatelessDeliveryOption(

--- a/apps/delivery-options/src/composables/useResolvedDeliveryOptions.spec.ts
+++ b/apps/delivery-options/src/composables/useResolvedDeliveryOptions.spec.ts
@@ -297,8 +297,10 @@ describe('useResolvedDeliveryOptions', () => {
 
   describe('same-day fallback moments', () => {
     // The legacy delivery options API does not support every carrier (e.g. Trunkrs).
-    // Carriers whose only delivery type is same-day get a synthetic moment for today
-    // as long as the same-day cutoff has not passed.
+    // Same-day carriers without API moments get a synthetic today-moment, but only
+    // when another carrier returned real API dates (so a date list exists to extend)
+    // and the same-day cutoff has not passed. Without any real API dates, the plain
+    // dateless fallback options cover these carriers instead.
     const CUTOFF_NOT_PASSED = '23:59';
     const CUTOFF_PASSED = '00:00';
 
@@ -328,7 +330,48 @@ describe('useResolvedDeliveryOptions', () => {
       return options;
     };
 
-    it('synthesizes a same-day moment for a same-day-only carrier without API moments', async () => {
+    const setupWithPostNlDates = async (
+      trunkrsSettings: Record<string, unknown>,
+      postNlDate = '2099-01-02 00:00:00',
+    ): Promise<ReturnType<typeof useResolvedDeliveryOptions>> => {
+      mockGetDeliveryOptions.mockImplementation((endpoint, opts) => {
+        void endpoint;
+
+        if (opts.parameters?.carrier === CarrierName.PostNl) {
+          return Promise.resolve([
+            {
+              date: createTimestamp(postNlDate),
+              possibilities: [createDeliveryPossibility(normalizeDate('2099-01-02T15:00:00'))],
+            },
+          ]);
+        }
+
+        return Promise.resolve([]);
+      });
+
+      mockDeliveryOptionsConfig(
+        getMockDeliveryOptionsConfiguration({
+          [KEY_CONFIG]: {
+            [KEY_CARRIER_SETTINGS]: {
+              [CarrierName.PostNl]: {
+                [CarrierSetting.AllowStandardDelivery]: true,
+              },
+              [CarrierName.Trunkrs]: trunkrsSettings,
+            },
+          },
+        }),
+      );
+
+      useResolvedDeliveryOptions.clear();
+      const options = useResolvedDeliveryOptions();
+      void options.load();
+      await waitFor(() => expect(options.loading.value).toBe(false), {timeout: 3000});
+      await flushPromises();
+
+      return options;
+    };
+
+    it('does not synthesize a same-day moment when no carrier got real API dates', async () => {
       const options = await setupWithEmptyApi({
         [CarrierName.Trunkrs]: {
           [CarrierSetting.AllowSameDayDelivery]: true,
@@ -336,35 +379,40 @@ describe('useResolvedDeliveryOptions', () => {
         },
       });
 
-      expect(options.value).toHaveLength(1);
+      expect(options.value).toEqual([]);
+    });
 
-      const [moment] = options.value;
+    it('synthesizes a tagged today-moment when another carrier has real API dates', async () => {
+      const options = await setupWithPostNlDates({
+        [CarrierSetting.AllowSameDayDelivery]: true,
+        [CarrierSetting.CutoffTimeSameDay]: CUTOFF_NOT_PASSED,
+      });
 
-      expect(moment.carrier).toBe(CarrierName.Trunkrs);
-      expect(moment.deliveryType).toBe(CustomDeliveryType.SameDay);
-      expect(moment.date && isToday(new Date(moment.date))).toBe(true);
+      const trunkrsMoment = options.value.find((moment) => moment.carrier === CarrierName.Trunkrs);
+      const postNlMoment = options.value.find((moment) => moment.carrier === CarrierName.PostNl);
+
+      expect(trunkrsMoment?.deliveryType).toBe(CustomDeliveryType.SameDay);
+      expect(trunkrsMoment?.date && isToday(new Date(trunkrsMoment.date))).toBe(true);
+      expect(trunkrsMoment?.isSynthetic).toBe(true);
+      expect(postNlMoment?.isSynthetic).toBeUndefined();
     });
 
     it('does not synthesize a same-day moment past the same-day cutoff', async () => {
-      const options = await setupWithEmptyApi({
-        [CarrierName.Trunkrs]: {
-          [CarrierSetting.AllowSameDayDelivery]: true,
-          [CarrierSetting.CutoffTimeSameDay]: CUTOFF_PASSED,
-        },
+      const options = await setupWithPostNlDates({
+        [CarrierSetting.AllowSameDayDelivery]: true,
+        [CarrierSetting.CutoffTimeSameDay]: CUTOFF_PASSED,
       });
 
-      expect(options.value).toEqual([]);
+      expect(options.value.some((moment) => moment.carrier === CarrierName.Trunkrs)).toBe(false);
     });
 
     it('does not synthesize a same-day moment when same-day delivery is disabled', async () => {
-      const options = await setupWithEmptyApi({
-        [CarrierName.Trunkrs]: {
-          [CarrierSetting.AllowSameDayDelivery]: false,
-          [CarrierSetting.CutoffTimeSameDay]: CUTOFF_NOT_PASSED,
-        },
+      const options = await setupWithPostNlDates({
+        [CarrierSetting.AllowSameDayDelivery]: false,
+        [CarrierSetting.CutoffTimeSameDay]: CUTOFF_NOT_PASSED,
       });
 
-      expect(options.value).toEqual([]);
+      expect(options.value.some((moment) => moment.carrier === CarrierName.Trunkrs)).toBe(false);
     });
 
     it('reuses the API today date string for synthesized moments so the date list stays deduplicated', async () => {

--- a/apps/delivery-options/src/composables/useResolvedDeliveryOptions.spec.ts
+++ b/apps/delivery-options/src/composables/useResolvedDeliveryOptions.spec.ts
@@ -1,5 +1,6 @@
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import {assign} from 'radash';
+import {format, isToday} from 'date-fns';
 import {normalizeDate} from '@vueuse/core';
 import {flushPromises} from '@vue/test-utils';
 import {waitFor} from '@testing-library/vue';
@@ -13,6 +14,7 @@ import {
   type InputDeliveryOptionsConfiguration,
   KEY_ADDRESS,
   ConfigSetting,
+  CustomDeliveryType,
 } from '@myparcel-dev/do-shared';
 import {DeliveryTypeName, CarrierName, PackageTypeName} from '@myparcel-dev/constants';
 import {useConfigStore} from '../stores';
@@ -290,6 +292,180 @@ describe('useResolvedDeliveryOptions', () => {
       const availableDates = await testClosedDaysFiltering(['2025-01-02'], 1, '16:00', '2025-01-01T15:00:00Z');
 
       expect(availableDates.some((date) => isDateMatch(date, 2025, 1, 2))).toBe(false);
+    });
+  });
+
+  describe('same-day fallback moments', () => {
+    // The legacy delivery options API does not support every carrier (e.g. Trunkrs).
+    // Carriers whose only delivery type is same-day get a synthetic moment for today
+    // as long as the same-day cutoff has not passed.
+    const CUTOFF_NOT_PASSED = '23:59';
+    const CUTOFF_PASSED = '00:00';
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    const setupWithEmptyApi = async (
+      carrierSettings: Record<string, Record<string, unknown>>,
+    ): Promise<ReturnType<typeof useResolvedDeliveryOptions>> => {
+      mockGetDeliveryOptions.mockResolvedValue([]);
+
+      mockDeliveryOptionsConfig(
+        getMockDeliveryOptionsConfiguration({
+          [KEY_CONFIG]: {
+            [KEY_CARRIER_SETTINGS]: carrierSettings,
+          },
+        }),
+      );
+
+      useResolvedDeliveryOptions.clear();
+      const options = useResolvedDeliveryOptions();
+      void options.load();
+      await waitFor(() => expect(options.loading.value).toBe(false), {timeout: 3000});
+      await flushPromises();
+
+      return options;
+    };
+
+    it('synthesizes a same-day moment for a same-day-only carrier without API moments', async () => {
+      const options = await setupWithEmptyApi({
+        [CarrierName.Trunkrs]: {
+          [CarrierSetting.AllowSameDayDelivery]: true,
+          [CarrierSetting.CutoffTimeSameDay]: CUTOFF_NOT_PASSED,
+        },
+      });
+
+      expect(options.value).toHaveLength(1);
+
+      const [moment] = options.value;
+
+      expect(moment.carrier).toBe(CarrierName.Trunkrs);
+      expect(moment.deliveryType).toBe(CustomDeliveryType.SameDay);
+      expect(moment.date && isToday(new Date(moment.date))).toBe(true);
+    });
+
+    it('does not synthesize a same-day moment past the same-day cutoff', async () => {
+      const options = await setupWithEmptyApi({
+        [CarrierName.Trunkrs]: {
+          [CarrierSetting.AllowSameDayDelivery]: true,
+          [CarrierSetting.CutoffTimeSameDay]: CUTOFF_PASSED,
+        },
+      });
+
+      expect(options.value).toEqual([]);
+    });
+
+    it('does not synthesize a same-day moment when same-day delivery is disabled', async () => {
+      const options = await setupWithEmptyApi({
+        [CarrierName.Trunkrs]: {
+          [CarrierSetting.AllowSameDayDelivery]: false,
+          [CarrierSetting.CutoffTimeSameDay]: CUTOFF_NOT_PASSED,
+        },
+      });
+
+      expect(options.value).toEqual([]);
+    });
+
+    it('reuses the API today date string for synthesized moments so the date list stays deduplicated', async () => {
+      // Another carrier may get a real today-date from the API (e.g. DHL For You
+      // same-day). The synthetic moment must share that exact date string, since
+      // the date string is the join key for the date picker and moment filtering.
+      const apiTodayDate = `${format(new Date(), 'yyyy-MM-dd')} 08:30:00`;
+
+      mockGetDeliveryOptions.mockImplementation((endpoint, opts) => {
+        void endpoint;
+
+        if (opts.parameters?.carrier === CarrierName.DhlForYou) {
+          return Promise.resolve([
+            {
+              date: createTimestamp(apiTodayDate),
+              possibilities: [createDeliveryPossibility(normalizeDate(new Date()))],
+            },
+          ]);
+        }
+
+        return Promise.resolve([]);
+      });
+
+      mockDeliveryOptionsConfig(
+        getMockDeliveryOptionsConfiguration({
+          [KEY_CONFIG]: {
+            [KEY_CARRIER_SETTINGS]: {
+              [CarrierName.DhlForYou]: {
+                [CarrierSetting.AllowStandardDelivery]: true,
+                [CarrierSetting.AllowSameDayDelivery]: true,
+                [CarrierSetting.CutoffTimeSameDay]: CUTOFF_NOT_PASSED,
+              },
+              [CarrierName.Trunkrs]: {
+                [CarrierSetting.AllowSameDayDelivery]: true,
+                [CarrierSetting.CutoffTimeSameDay]: CUTOFF_NOT_PASSED,
+              },
+            },
+          },
+        }),
+      );
+
+      useResolvedDeliveryOptions.clear();
+      const options = useResolvedDeliveryOptions();
+      void options.load();
+      await waitFor(() => expect(options.loading.value).toBe(false), {timeout: 3000});
+      await flushPromises();
+
+      const trunkrsMoment = options.value.find((moment) => moment.carrier === CarrierName.Trunkrs);
+      const dhlMoment = options.value.find((moment) => moment.carrier === CarrierName.DhlForYou);
+
+      expect(dhlMoment?.date).toBe(apiTodayDate);
+      expect(trunkrsMoment?.date).toBe(apiTodayDate);
+    });
+
+    it('does not synthesize a same-day moment when the API returns dates without today', async () => {
+      // The API is authoritative when it responds with dates: a carrier that
+      // supports both same-day and standard delivery, but gets no today-date
+      // back, must only render the dates the API returned.
+      mockGetDeliveryOptions.mockResolvedValue([
+        {
+          date: createTimestamp('2099-01-02 00:00:00'),
+          possibilities: [createDeliveryPossibility(normalizeDate('2099-01-02T15:00:00'))],
+        },
+      ]);
+
+      mockDeliveryOptionsConfig(
+        getMockDeliveryOptionsConfiguration({
+          [KEY_CONFIG]: {
+            [KEY_CARRIER_SETTINGS]: {
+              [CarrierName.DhlForYou]: {
+                [CarrierSetting.AllowStandardDelivery]: true,
+                [CarrierSetting.AllowSameDayDelivery]: true,
+                [CarrierSetting.CutoffTimeSameDay]: CUTOFF_NOT_PASSED,
+              },
+            },
+          },
+        }),
+      );
+
+      useResolvedDeliveryOptions.clear();
+      const options = useResolvedDeliveryOptions();
+      void options.load();
+      await waitFor(() => expect(options.loading.value).toBe(false), {timeout: 3000});
+      await flushPromises();
+
+      const deliveryTypes = options.value.map((moment) => moment.deliveryType);
+
+      expect(deliveryTypes).toContain(DeliveryTypeName.Standard);
+      expect(deliveryTypes).not.toContain(CustomDeliveryType.SameDay);
+    });
+
+    it('does not synthesize a same-day moment for carriers without same-day support', async () => {
+      const options = await setupWithEmptyApi({
+        [CarrierName.PostNl]: {
+          [CarrierSetting.AllowStandardDelivery]: true,
+          [CarrierSetting.AllowSameDayDelivery]: true,
+          [CarrierSetting.CutoffTimeSameDay]: CUTOFF_NOT_PASSED,
+        },
+      });
+
+      expect(options.value).toEqual([]);
     });
   });
 

--- a/apps/delivery-options/src/composables/useResolvedDeliveryOptions.ts
+++ b/apps/delivery-options/src/composables/useResolvedDeliveryOptions.ts
@@ -1,6 +1,6 @@
 import {toValue, watch, type ComputedRef} from 'vue';
 import {pascal} from 'radash';
-import {startOfDay} from 'date-fns';
+import {format, isToday, startOfDay} from 'date-fns';
 import {useMemoize} from '@vueuse/core';
 import {
   useDeliveryOptionsRequest,
@@ -9,11 +9,19 @@ import {
   createUntranslatable,
   type ComputedAsync,
   CarrierSetting,
+  CustomDeliveryType,
   DELIVERY_DAYS_WINDOW_DEFAULT,
   createTranslatable,
   ConfigSetting,
 } from '@myparcel-dev/do-shared';
-import {createGetDeliveryOptionsParameters, getResolvedDeliveryType, calculateCutoffTime} from '../utils';
+import {
+  createGetDeliveryOptionsParameters,
+  getResolvedDeliveryType,
+  calculateCutoffTime,
+  isFallbackEligible,
+  isSameDayAvailable,
+  stringToDate,
+} from '../utils';
 import {type SelectedDeliveryMoment} from '../types';
 import {useConfigStore} from '../stores';
 import {DELIVERY_MOMENT_PACKAGE_TYPES} from '../data';
@@ -315,6 +323,7 @@ const formatDatesAsDeliveryMoments = (
           date: dateOption.date?.date,
           time: timeString,
           deliveryType,
+          originalDeliveryType: datePossibility.type,
           packageType: datePossibility.package_type,
           shipmentOptions: datePossibility.shipment_options,
         });
@@ -323,6 +332,41 @@ const formatDatesAsDeliveryMoments = (
 
     return acc;
   }, [] as SelectedDeliveryMoment[]);
+};
+
+/**
+ * The legacy delivery options API does not support every carrier (e.g. Trunkrs).
+ * Carriers with same-day delivery enabled and available that got no dates from
+ * the API receive a synthetic moment for today, as long as their same-day
+ * cutoff has not passed. Remove when the API supports these carriers.
+ */
+const createSameDayFallbackMoments = (
+  carriers: UseResolvedCarrier[],
+  moments: SelectedDeliveryMoment[],
+): SelectedDeliveryMoment[] => {
+  const {state: config} = useConfigStore();
+
+  if (!DELIVERY_MOMENT_PACKAGE_TYPES.includes(config.packageType)) {
+    return [];
+  }
+
+  const carriersWithMoments = new Set(moments.map((moment) => moment.carrier));
+
+  // The date string is the join key for the date picker and moment filtering,
+  // so reuse the date string of an existing API today-moment when there is one.
+  const todayFromApi = moments.find((moment) => moment.date && isToday(stringToDate(moment.date)))?.date;
+  const todayDate = todayFromApi ?? `${format(new Date(), 'yyyy-MM-dd')} 00:00:00`;
+
+  return carriers
+    .filter((carrier) => isFallbackEligible(carrier, carriersWithMoments) && isSameDayAvailable(carrier))
+    .map((carrier) => ({
+      carrier: toValue(carrier.carrier).identifier,
+      date: todayDate,
+      time: createTranslatable(`delivery${pascal(CustomDeliveryType.SameDay)}Title`),
+      deliveryType: CustomDeliveryType.SameDay,
+      packageType: config.packageType,
+      shipmentOptions: [],
+    }));
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -366,7 +410,9 @@ const callback = (): UseResolvedDeliveryOptions => {
     const filteredDates = removeEmptyEntries(datesPerCarrier, toValue(carriers));
 
     // Flatten the dates into SelectedDeliveryMoment objects.
-    return formatDatesAsDeliveryMoments(filteredDates);
+    const moments = formatDatesAsDeliveryMoments(filteredDates);
+
+    return [...moments, ...createSameDayFallbackMoments(toValue(carriers), moments)];
   }, []);
 };
 

--- a/apps/delivery-options/src/composables/useResolvedDeliveryOptions.ts
+++ b/apps/delivery-options/src/composables/useResolvedDeliveryOptions.ts
@@ -8,6 +8,7 @@ import {
   type AnyTranslatable,
   createUntranslatable,
   type ComputedAsync,
+  API_DATE_FORMAT,
   CarrierSetting,
   CustomDeliveryType,
   DELIVERY_DAYS_WINDOW_DEFAULT,
@@ -358,7 +359,7 @@ const createSameDayFallbackMoments = (
   // The date string is the join key for the date picker and moment filtering,
   // so reuse the date string of an existing API today-moment when there is one.
   const todayFromApi = moments.find((moment) => moment.date && isToday(stringToDate(moment.date)))?.date;
-  const todayDate = todayFromApi ?? `${format(new Date(), 'yyyy-MM-dd')} 00:00:00`;
+  const todayDate = todayFromApi ?? format(startOfDay(new Date()), API_DATE_FORMAT);
 
   return carriers
     .filter((carrier) => isFallbackEligible(carrier, carriersWithMoments) && isSameDayAvailable(carrier))

--- a/apps/delivery-options/src/composables/useResolvedDeliveryOptions.ts
+++ b/apps/delivery-options/src/composables/useResolvedDeliveryOptions.ts
@@ -338,7 +338,10 @@ const formatDatesAsDeliveryMoments = (
  * The legacy delivery options API does not support every carrier (e.g. Trunkrs).
  * Carriers with same-day delivery enabled and available that got no dates from
  * the API receive a synthetic moment for today, as long as their same-day
- * cutoff has not passed. Remove when the API supports these carriers.
+ * cutoff has not passed and at least one carrier returned real API dates (so
+ * there is a date list to extend). Without any real API dates the dateless
+ * fallback options cover these carriers instead. Remove when the API supports
+ * these carriers.
  */
 const createSameDayFallbackMoments = (
   carriers: UseResolvedCarrier[],
@@ -346,7 +349,7 @@ const createSameDayFallbackMoments = (
 ): SelectedDeliveryMoment[] => {
   const {state: config} = useConfigStore();
 
-  if (!DELIVERY_MOMENT_PACKAGE_TYPES.includes(config.packageType)) {
+  if (!DELIVERY_MOMENT_PACKAGE_TYPES.includes(config.packageType) || moments.length === 0) {
     return [];
   }
 
@@ -362,6 +365,7 @@ const createSameDayFallbackMoments = (
     .map((carrier) => ({
       carrier: toValue(carrier.carrier).identifier,
       date: todayDate,
+      isSynthetic: true,
       time: createTranslatable(`delivery${pascal(CustomDeliveryType.SameDay)}Title`),
       deliveryType: CustomDeliveryType.SameDay,
       packageType: config.packageType,

--- a/apps/delivery-options/src/config/getDefaultStrings.ts
+++ b/apps/delivery-options/src/config/getDefaultStrings.ts
@@ -79,6 +79,7 @@ export const getDefaultStrings = (): Record<string, string> => ({
   // Title of options
   [DELIVERY_TITLE]: 'Thuis of op het werk bezorgen',
   deliveryStandardTitle: 'Standaard bezorging',
+  deliverySameDayTitle: 'Vandaag bezorgd',
   [ECO_FRIENDLY]: 'Meest milieuvriendelijk',
   [NO_DELIVERY_OPTIONS_AVAILABLE]: 'Geen bezorgopties beschikbaar',
   [ONLY_RECIPIENT_TITLE]: 'Alleen ontvanger',

--- a/apps/delivery-options/src/stores/useConfigStore.spec.ts
+++ b/apps/delivery-options/src/stores/useConfigStore.spec.ts
@@ -1,0 +1,31 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import {useMockSdk} from '@myparcel-dev/do-shared/testing';
+import {useSdk, type DeliveryOptionsConfig} from '@myparcel-dev/do-shared';
+import {useConfigStore} from './useConfigStore';
+
+const ACCEPTANCE_URL = 'https://api.acceptance.myparcel.nl';
+
+describe('useConfigStore', () => {
+  beforeEach(() => {
+    useConfigStore().reset();
+  });
+
+  it('applies apiBaseUrl to the sdk client', () => {
+    const {clientConfig} = useMockSdk();
+
+    useConfigStore().update({apiBaseUrl: ACCEPTANCE_URL} as DeliveryOptionsConfig);
+    useSdk();
+
+    expect(clientConfig.value?.baseUrl).toBe(ACCEPTANCE_URL);
+  });
+
+  it('restores the default sdk base url on reset', () => {
+    const {clientConfig} = useMockSdk();
+
+    useConfigStore().update({apiBaseUrl: ACCEPTANCE_URL} as DeliveryOptionsConfig);
+    useConfigStore().reset();
+    useSdk();
+
+    expect(clientConfig.value?.baseUrl).toBe('https://api.myparcel.nl');
+  });
+});

--- a/apps/delivery-options/src/stores/useConfigStore.ts
+++ b/apps/delivery-options/src/stores/useConfigStore.ts
@@ -3,6 +3,7 @@ import {reactive} from 'vue';
 import {assign} from 'radash';
 import {
   getDefaultDeliveryOptionsConfig,
+  setSdkBaseUrl,
   type DeliveryOptionsConfig,
   type ResolvedDeliveryOptionsConfig,
 } from '@myparcel-dev/do-shared';
@@ -17,6 +18,8 @@ function update(configuration: DeliveryOptionsConfig, withDefaults = true): void
   } else {
     Object.assign(state, configuration);
   }
+
+  setSdkBaseUrl(state.apiBaseUrl);
 }
 
 // Reset to the initial state
@@ -27,6 +30,8 @@ function reset(): void {
   }
 
   Object.assign(state, initialState);
+
+  setSdkBaseUrl(state.apiBaseUrl);
 }
 
 export const useConfigStore = (): DeliveryOptionsStore<

--- a/apps/delivery-options/src/types/form.types.ts
+++ b/apps/delivery-options/src/types/form.types.ts
@@ -14,6 +14,13 @@ export interface ResolvedDeliveryOptions {
   carrier: CarrierIdentifier;
   date: undefined | string;
   deliveryType: DeliveryTypeName;
+  /**
+   * The delivery type as returned by the API, before being resolved to a custom
+   * type (e.g. an evening moment dated today resolves to same_day). Internal
+   * tracking only: used to emit the actual delivery type for carriers exposing
+   * same-day as a shipment option. Never part of the external output.
+   */
+  originalDeliveryType?: DeliveryTypeName;
   packageType: PackageTypeName;
   shipmentOptions: DeepReadonly<DeliveryOption['possibilities'][number]['shipment_options']>;
   time: AnyTranslatable;

--- a/apps/delivery-options/src/types/form.types.ts
+++ b/apps/delivery-options/src/types/form.types.ts
@@ -21,6 +21,13 @@ export interface ResolvedDeliveryOptions {
    * same-day as a shipment option. Never part of the external output.
    */
   originalDeliveryType?: DeliveryTypeName;
+  /**
+   * True for moments the widget synthesized itself (e.g. the same-day today
+   * moment for carriers the legacy delivery options API does not support).
+   * Synthetic moments do not count as real API data when deciding fallback
+   * eligibility. Never part of the external output.
+   */
+  isSynthetic?: boolean;
   packageType: PackageTypeName;
   shipmentOptions: DeepReadonly<DeliveryOption['possibilities'][number]['shipment_options']>;
   time: AnyTranslatable;

--- a/apps/delivery-options/src/utils/getCapabilityDeliveryTypes.spec.ts
+++ b/apps/delivery-options/src/utils/getCapabilityDeliveryTypes.spec.ts
@@ -46,6 +46,20 @@ describe('getCapabilityDeliveryTypes', () => {
     ]);
   });
 
+  it('maps the same day delivery type to the same_day custom type', () => {
+    const cap = createCapability(['SAME_DAY_DELIVERY']);
+
+    expect(getCapabilityDeliveryTypes(cap)).toEqual([CustomDeliveryType.SameDay]);
+  });
+
+  it('does not duplicate same_day when exposed as both delivery type and option', () => {
+    const cap = createCapability(['SAME_DAY_DELIVERY'], {
+      sameDayDelivery: {requires: [], excludes: [], isSelectedByDefault: false, isRequired: false},
+    });
+
+    expect(getCapabilityDeliveryTypes(cap)).toEqual([CustomDeliveryType.SameDay]);
+  });
+
   it('returns empty array for empty capabilities', () => {
     const cap = createCapability();
 

--- a/apps/delivery-options/src/utils/hasDeliveryForCarrier.spec.ts
+++ b/apps/delivery-options/src/utils/hasDeliveryForCarrier.spec.ts
@@ -52,6 +52,18 @@ describe('hasDeliveryForCarrier', () => {
     expect(hasDeliveryForCarrier(cap)).toBe(false);
   });
 
+  it('returns true when capability only has the same day delivery type and config allows it', () => {
+    mockDeliveryOptionsConfig(
+      getMockDeliveryOptionsConfiguration({
+        [KEY_CONFIG]: {[CarrierSetting.AllowSameDayDelivery]: true},
+      }),
+    );
+
+    const cap = createCapability(['SAME_DAY_DELIVERY']);
+
+    expect(hasDeliveryForCarrier(cap)).toBe(true);
+  });
+
   it('returns false when capability has no delivery types', () => {
     mockDeliveryOptionsConfig(
       getMockDeliveryOptionsConfiguration({

--- a/apps/delivery-options/src/utils/index.ts
+++ b/apps/delivery-options/src/utils/index.ts
@@ -17,6 +17,8 @@ export * from './getResolvedValue';
 export * from './hasDeliveryForCarrier';
 export * from './hasPickupForCarrier';
 export * from './hasSlotContent';
+export * from './isFallbackEligible';
+export * from './isSameDayAvailable';
 export * from './language';
 export * from './padTime';
 export * from './parseJson';

--- a/apps/delivery-options/src/utils/index.ts
+++ b/apps/delivery-options/src/utils/index.ts
@@ -24,4 +24,5 @@ export * from './padTime';
 export * from './parseJson';
 export * from './showDeveloperInfo';
 export * from './stringToDate';
+export * from './supportsSameDay';
 export * from './toTime';

--- a/apps/delivery-options/src/utils/isFallbackEligible.ts
+++ b/apps/delivery-options/src/utils/isFallbackEligible.ts
@@ -1,0 +1,21 @@
+import {toValue} from 'vue';
+import {CarrierSetting, DELIVERY_DAYS_WINDOW_DEFAULT, type CarrierIdentifier} from '@myparcel-dev/do-shared';
+import {type UseResolvedCarrier} from '../composables';
+
+/**
+ * Whether a carrier qualifies for a fallback delivery option: it received no
+ * delivery moments from the API, has delivery, and shows delivery days. Callers
+ * add their own representation-specific condition (standard or same-day support).
+ */
+export const isFallbackEligible = (
+  carrier: UseResolvedCarrier,
+  carriersWithMoments: ReadonlySet<CarrierIdentifier>,
+): boolean => {
+  const {identifier} = toValue(carrier.carrier);
+
+  if (carriersWithMoments.has(identifier) || !toValue(carrier.hasDelivery)) {
+    return false;
+  }
+
+  return carrier.get(CarrierSetting.DeliveryDaysWindow, DELIVERY_DAYS_WINDOW_DEFAULT) !== 0;
+};

--- a/apps/delivery-options/src/utils/isSameDayAvailable.spec.ts
+++ b/apps/delivery-options/src/utils/isSameDayAvailable.spec.ts
@@ -1,0 +1,97 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {flushPromises} from '@vue/test-utils';
+import {KEY_CONFIG, CarrierSetting, KEY_CARRIER_SETTINGS} from '@myparcel-dev/do-shared';
+import {CarrierName} from '@myparcel-dev/constants';
+import {useConfigStore} from '../stores';
+import {mockDeliveryOptionsConfig} from '../__tests__';
+import {getResolvedCarrier} from './getResolvedCarrier';
+import {isSameDayAvailable} from './isSameDayAvailable';
+
+// 2021-01-04 is a Monday: getDay() === 1.
+const MONDAY_15_00 = new Date('2021-01-04T15:00') as Readonly<Date>;
+
+const getIsSameDayAvailable = async (carrierName: string = CarrierName.Trunkrs): Promise<boolean> => {
+  const resolvedCarrier = getResolvedCarrier(carrierName as CarrierName);
+
+  await flushPromises();
+
+  return isSameDayAvailable(resolvedCarrier);
+};
+
+describe('isSameDayAvailable', () => {
+  beforeEach(() => {
+    useConfigStore().reset();
+    vi.setSystemTime(MONDAY_15_00);
+  });
+
+  afterEach(() => {
+    vi.setSystemTime(vi.getRealSystemTime());
+  });
+
+  it('uses the same-day cutoff from the current drop-off day', async () => {
+    mockDeliveryOptionsConfig({
+      [KEY_CONFIG]: {
+        [KEY_CARRIER_SETTINGS]: {
+          [CarrierName.Trunkrs]: {
+            [CarrierSetting.AllowSameDayDelivery]: true,
+            [CarrierSetting.DropOffDays]: [
+              {weekday: 1, cutoffTime: '17:00', [CarrierSetting.CutoffTimeSameDay]: '23:30'},
+            ],
+          },
+        },
+      },
+    });
+
+    await expect(getIsSameDayAvailable()).resolves.toBe(true);
+  });
+
+  it('is unavailable past the drop-off day same-day cutoff', async () => {
+    mockDeliveryOptionsConfig({
+      [KEY_CONFIG]: {
+        [KEY_CARRIER_SETTINGS]: {
+          [CarrierName.Trunkrs]: {
+            [CarrierSetting.AllowSameDayDelivery]: true,
+            [CarrierSetting.DropOffDays]: [
+              {weekday: 1, cutoffTime: '17:00', [CarrierSetting.CutoffTimeSameDay]: '14:00'},
+            ],
+          },
+        },
+      },
+    });
+
+    await expect(getIsSameDayAvailable()).resolves.toBe(false);
+  });
+
+  it('falls back to the flat same-day cutoff when the drop-off day has none', async () => {
+    mockDeliveryOptionsConfig({
+      [KEY_CONFIG]: {
+        [KEY_CARRIER_SETTINGS]: {
+          [CarrierName.Trunkrs]: {
+            [CarrierSetting.AllowSameDayDelivery]: true,
+            [CarrierSetting.CutoffTimeSameDay]: '16:00',
+            [CarrierSetting.DropOffDays]: [{weekday: 1, cutoffTime: '17:00'}],
+          },
+        },
+      },
+    });
+
+    await expect(getIsSameDayAvailable()).resolves.toBe(true);
+  });
+
+  it('is unavailable for carriers without same-day support', async () => {
+    mockDeliveryOptionsConfig({
+      [KEY_CONFIG]: {
+        [KEY_CARRIER_SETTINGS]: {
+          [CarrierName.PostNl]: {
+            [CarrierSetting.AllowSameDayDelivery]: true,
+            [CarrierSetting.DropOffDays]: [
+              {weekday: 1, cutoffTime: '17:00', [CarrierSetting.CutoffTimeSameDay]: '23:30'},
+            ],
+          },
+        },
+      },
+    });
+
+    await expect(getIsSameDayAvailable(CarrierName.PostNl)).resolves.toBe(false);
+  });
+});

--- a/apps/delivery-options/src/utils/isSameDayAvailable.ts
+++ b/apps/delivery-options/src/utils/isSameDayAvailable.ts
@@ -1,16 +1,16 @@
-import {toValue} from 'vue';
-import {CustomDeliveryType, isPastTime} from '@myparcel-dev/do-shared';
+import {isPastTime} from '@myparcel-dev/do-shared';
 import {type UseResolvedCarrier} from '../composables';
+import {supportsSameDay} from './supportsSameDay';
 import {calculateCutoffTime} from './calculateCutoffTime';
 
 /**
- * Whether same-day delivery can currently be offered for this carrier:
- * available in its capabilities, enabled in the config, and before the
- * carrier's same-day cutoff time. The cutoff comes from today's drop-off day
- * entry when present, falling back to the flat cutoffTimeSameDay setting.
+ * Whether same-day delivery can be offered for delivery on today itself: the
+ * carrier supports it and the same-day cutoff time has not passed. The cutoff
+ * comes from today's drop-off day entry when present, falling back to the
+ * flat cutoffTimeSameDay setting.
  */
 export const isSameDayAvailable = (carrier: UseResolvedCarrier): boolean => {
-  if (!toValue(carrier.deliveryTypes).has(CustomDeliveryType.SameDay)) {
+  if (!supportsSameDay(carrier)) {
     return false;
   }
 

--- a/apps/delivery-options/src/utils/isSameDayAvailable.ts
+++ b/apps/delivery-options/src/utils/isSameDayAvailable.ts
@@ -1,0 +1,19 @@
+import {toValue} from 'vue';
+import {CustomDeliveryType, isPastTime} from '@myparcel-dev/do-shared';
+import {type UseResolvedCarrier} from '../composables';
+import {calculateCutoffTime} from './calculateCutoffTime';
+
+/**
+ * Whether same-day delivery can currently be offered for this carrier:
+ * available in its capabilities, enabled in the config, and before the
+ * carrier's same-day cutoff time. The cutoff comes from today's drop-off day
+ * entry when present, falling back to the flat cutoffTimeSameDay setting.
+ */
+export const isSameDayAvailable = (carrier: UseResolvedCarrier): boolean => {
+  if (!toValue(carrier.deliveryTypes).has(CustomDeliveryType.SameDay)) {
+    return false;
+  }
+
+  // calculateCutoffTime returns the same-day cutoff for same-day capable carriers.
+  return !isPastTime(calculateCutoffTime(carrier));
+};

--- a/apps/delivery-options/src/utils/supportsSameDay.spec.ts
+++ b/apps/delivery-options/src/utils/supportsSameDay.spec.ts
@@ -1,0 +1,83 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {flushPromises} from '@vue/test-utils';
+import {KEY_CONFIG, CarrierSetting, KEY_CARRIER_SETTINGS} from '@myparcel-dev/do-shared';
+import {CarrierName} from '@myparcel-dev/constants';
+import {useConfigStore} from '../stores';
+import {mockDeliveryOptionsConfig} from '../__tests__';
+import {supportsSameDay} from './supportsSameDay';
+import {getResolvedCarrier} from './getResolvedCarrier';
+
+const getSupportsSameDay = async (carrierName: string = CarrierName.Trunkrs): Promise<boolean> => {
+  const resolvedCarrier = getResolvedCarrier(carrierName as CarrierName);
+
+  await flushPromises();
+
+  return supportsSameDay(resolvedCarrier);
+};
+
+describe('supportsSameDay', () => {
+  beforeEach(() => {
+    useConfigStore().reset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is true for a same-day capable carrier with same-day enabled', async () => {
+    mockDeliveryOptionsConfig({
+      [KEY_CONFIG]: {
+        [KEY_CARRIER_SETTINGS]: {
+          [CarrierName.Trunkrs]: {
+            [CarrierSetting.AllowSameDayDelivery]: true,
+          },
+        },
+      },
+    });
+
+    await expect(getSupportsSameDay()).resolves.toBe(true);
+  });
+
+  it('is true regardless of the cutoff time having passed', async () => {
+    mockDeliveryOptionsConfig({
+      [KEY_CONFIG]: {
+        [KEY_CARRIER_SETTINGS]: {
+          [CarrierName.Trunkrs]: {
+            [CarrierSetting.AllowSameDayDelivery]: true,
+            [CarrierSetting.CutoffTimeSameDay]: '00:00',
+          },
+        },
+      },
+    });
+
+    await expect(getSupportsSameDay()).resolves.toBe(true);
+  });
+
+  it('is false when same-day delivery is disabled', async () => {
+    mockDeliveryOptionsConfig({
+      [KEY_CONFIG]: {
+        [KEY_CARRIER_SETTINGS]: {
+          [CarrierName.Trunkrs]: {
+            [CarrierSetting.AllowSameDayDelivery]: false,
+          },
+        },
+      },
+    });
+
+    await expect(getSupportsSameDay()).resolves.toBe(false);
+  });
+
+  it('is false for carriers without same-day capability', async () => {
+    mockDeliveryOptionsConfig({
+      [KEY_CONFIG]: {
+        [KEY_CARRIER_SETTINGS]: {
+          [CarrierName.PostNl]: {
+            [CarrierSetting.AllowSameDayDelivery]: true,
+          },
+        },
+      },
+    });
+
+    await expect(getSupportsSameDay(CarrierName.PostNl)).resolves.toBe(false);
+  });
+});

--- a/apps/delivery-options/src/utils/supportsSameDay.ts
+++ b/apps/delivery-options/src/utils/supportsSameDay.ts
@@ -1,0 +1,11 @@
+import {toValue} from 'vue';
+import {CustomDeliveryType} from '@myparcel-dev/do-shared';
+import {type UseResolvedCarrier} from '../composables';
+
+/**
+ * Whether this carrier offers same-day delivery: available in its capabilities
+ * and enabled in the config. Ignores the cutoff time; that only matters when
+ * the delivery day is today (see isSameDayAvailable).
+ */
+export const supportsSameDay = (carrier: UseResolvedCarrier): boolean =>
+  toValue(carrier.deliveryTypes).has(CustomDeliveryType.SameDay);

--- a/apps/sandbox/src/components/SandboxApiKeyBox.vue
+++ b/apps/sandbox/src/components/SandboxApiKeyBox.vue
@@ -10,6 +10,12 @@
           v-model="apiKey"
           class="mp-w-full" />
 
+        <h2 v-text="translate('api_base_url_header')" />
+        <FormTextInput
+          v-model="apiBaseUrl"
+          :placeholder="DEFAULT_API_BASE_URL"
+          class="mp-w-full" />
+
         <h2 v-text="translate('platform_header')" />
         <FormSelectInput
           v-model="platform"
@@ -22,6 +28,7 @@
 <script lang="ts" setup>
 import {computed} from 'vue';
 import {useSandboxStore} from '../stores';
+import {DEFAULT_API_BASE_URL} from '../constants';
 import {useLanguage} from '../composables';
 import FormTextInput from './form/input/FormTextInput.vue';
 import FormSelectInput from './form/input/FormSelectInput.vue';
@@ -37,6 +44,15 @@ const apiKey = computed({
   get: () => sandboxStore.config.apiKey ?? '',
   set: (value) => {
     sandboxStore.config.apiKey = value || undefined;
+  },
+});
+
+// Override the API the sandbox talks to (e.g. https://api.acceptance.myparcel.nl
+// with a matching acceptance API key). Empty means production.
+const apiBaseUrl = computed({
+  get: () => sandboxStore.config.apiBaseUrl ?? '',
+  set: (value) => {
+    sandboxStore.config.apiBaseUrl = value || undefined;
   },
 });
 

--- a/apps/sandbox/src/composables/useSandboxCapabilities.ts
+++ b/apps/sandbox/src/composables/useSandboxCapabilities.ts
@@ -7,12 +7,12 @@ import {getProxyCapabilitiesUrl} from '../constants';
 export const useSandboxCapabilities = useMemoize(() => {
   const store = useSandboxStore();
 
-  const proxyCapabilities = getProxyCapabilitiesUrl(store.config.apiBaseUrl);
+  // Pass a getter so the url follows the apiBaseUrl override reactively;
+  // a plain value would be snapshotted before the user can change it.
+  const proxyCapabilities = (): string => getProxyCapabilitiesUrl(store.config.apiBaseUrl);
 
   const request = computed(() => {
-    const capPackageType = store.config.packageType
-      ? mapPackageTypeToCapability(store.config.packageType)
-      : undefined;
+    const capPackageType = store.config.packageType ? mapPackageTypeToCapability(store.config.packageType) : undefined;
 
     return {
       recipient: {

--- a/apps/sandbox/src/constants.ts
+++ b/apps/sandbox/src/constants.ts
@@ -1,6 +1,6 @@
 import {type LanguageDefinition} from './types';
 
-const DEFAULT_API_BASE_URL = 'https://api.myparcel.nl';
+export const DEFAULT_API_BASE_URL = 'https://api.myparcel.nl';
 
 export const getProxyCapabilitiesUrl = (apiBaseUrl?: string): string =>
   `${apiBaseUrl ?? DEFAULT_API_BASE_URL}/shipments/capabilities`;

--- a/apps/sandbox/src/form/availableInPlatform.spec.ts
+++ b/apps/sandbox/src/form/availableInPlatform.spec.ts
@@ -86,4 +86,26 @@ describe('availableInCarrier', () => {
 
     expect(availableInCarrier(`unknown.${CarrierSetting.AllowStandardDelivery}`)).toBe(true);
   });
+
+  it('returns true for same day when exposed as a delivery type', () => {
+    __setMockCapabilities([createCapability('trunkrs', ['SAME_DAY_DELIVERY'])]);
+
+    expect(availableInCarrier(`trunkrs.${CarrierSetting.AllowSameDayDelivery}`)).toBe(true);
+  });
+
+  it('returns true for same day when exposed as an option', () => {
+    __setMockCapabilities([
+      createCapability('dhlforyou', ['STANDARD_DELIVERY'], {
+        sameDayDelivery: {requires: [], excludes: [], isSelectedByDefault: false, isRequired: false},
+      }),
+    ]);
+
+    expect(availableInCarrier(`dhlforyou.${CarrierSetting.AllowSameDayDelivery}`)).toBe(true);
+  });
+
+  it('returns false for same day when neither representation is present', () => {
+    __setMockCapabilities([createCapability('postnl', ['STANDARD_DELIVERY'])]);
+
+    expect(availableInCarrier(`postnl.${CarrierSetting.AllowSameDayDelivery}`)).toBe(false);
+  });
 });

--- a/apps/sandbox/src/form/availableInPlatform.ts
+++ b/apps/sandbox/src/form/availableInPlatform.ts
@@ -1,9 +1,12 @@
-import {type CarrierSetting, mapCarrierSettingToCapabilityKey} from '@myparcel-dev/do-shared';
+import {type CarrierSetting, mapCarrierSettingToCapabilityKeys} from '@myparcel-dev/do-shared';
 import {useSandboxCapabilities} from '../composables';
 
 /**
  * Check if a given carrier setting is supported by the carrier's capabilities.
- * Settings without a capability mapping (e.g. prices, dropoff config) are always shown.
+ * Settings without a capability mapping (e.g. prices, dropoff config) are always
+ * shown. Settings with multiple capability representations (e.g. same-day, which
+ * is a delivery type on some carriers and an option on others) are shown when
+ * any representation matches.
  */
 export const availableInCarrier = (fieldPath: string): boolean => {
   const parts = fieldPath.split('.');
@@ -14,9 +17,9 @@ export const availableInCarrier = (fieldPath: string): boolean => {
     return true;
   }
 
-  const capMapping = mapCarrierSettingToCapabilityKey(settingKey);
+  const capMappings = mapCarrierSettingToCapabilityKeys(settingKey);
 
-  if (!capMapping) {
+  if (capMappings.length === 0) {
     return true;
   }
 
@@ -27,9 +30,7 @@ export const availableInCarrier = (fieldPath: string): boolean => {
     return true;
   }
 
-  if (capMapping.type === 'deliveryType') {
-    return cap.deliveryTypes.includes(capMapping.name);
-  }
-
-  return capMapping.name in cap.options;
+  return capMappings.some((capMapping) =>
+    capMapping.type === 'deliveryType' ? cap.deliveryTypes.includes(capMapping.name) : capMapping.name in cap.options,
+  );
 };

--- a/apps/sandbox/src/form/getAllSandboxConfigOptions.spec.ts
+++ b/apps/sandbox/src/form/getAllSandboxConfigOptions.spec.ts
@@ -1,0 +1,14 @@
+import {describe, it, expect} from 'vitest';
+import {CarrierSetting} from '@myparcel-dev/do-shared';
+import {getAllSandboxConfigOptions, type SandboxConfigOption} from './getAllSandboxConfigOptions';
+
+describe('getAllSandboxConfigOptions', () => {
+  it('nests the same day cutoff time under the same day toggle', () => {
+    const option: SandboxConfigOption | undefined = getAllSandboxConfigOptions().find(
+      (item) => item.key === CarrierSetting.CutoffTimeSameDay,
+    );
+
+    expect(option).toBeDefined();
+    expect(option?.parents).toEqual([CarrierSetting.AllowSameDayDelivery]);
+  });
+});

--- a/apps/sandbox/src/form/getAllSandboxConfigOptions.ts
+++ b/apps/sandbox/src/form/getAllSandboxConfigOptions.ts
@@ -12,6 +12,7 @@ const extended = Object.freeze([
 
   {key: CarrierSetting.AllowSameDayDelivery},
   {key: CarrierSetting.PriceSameDayDelivery, parents: [CarrierSetting.AllowSameDayDelivery]},
+  {key: CarrierSetting.CutoffTimeSameDay, parents: [CarrierSetting.AllowSameDayDelivery]},
 
   {key: CarrierSetting.AllowExpressDelivery},
   {key: CarrierSetting.PriceExpressDelivery, parents: [CarrierSetting.AllowExpressDelivery]},

--- a/libs/shared/src/__tests__/index.ts
+++ b/libs/shared/src/__tests__/index.ts
@@ -1,4 +1,5 @@
 export * from './carriers';
 export * from './mocks';
 export * from './types';
+export * from './useMockSdk';
 export * from './utils';

--- a/libs/shared/src/__tests__/mocks/mockCapabilitiesResponse.ts
+++ b/libs/shared/src/__tests__/mocks/mockCapabilitiesResponse.ts
@@ -89,6 +89,16 @@ export const MOCK_CAPABILITIES: CarrierCapability[] = [
     },
     collo: {max: 20},
   },
+  {
+    carrier: 'TRUNKRS',
+    packageTypes: ['PACKAGE'],
+    // Same-day as a delivery type (not a sameDayDelivery option) — mirrors the real Trunkrs contract.
+    deliveryTypes: ['SAME_DAY_DELIVERY'],
+    options: {
+      requiresSignature: {...DEFAULT_OPTION},
+    },
+    collo: {max: 20},
+  },
 ];
 
 export const MOCK_CAPABILITIES_RESPONSE: CapabilitiesResponse = {

--- a/libs/shared/src/composables/useSdk.spec.ts
+++ b/libs/shared/src/composables/useSdk.spec.ts
@@ -1,6 +1,6 @@
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, afterEach} from 'vitest';
 import {useMockSdk} from '../__tests__/useMockSdk';
-import {useSdk} from './useSdk';
+import {setSdkBaseUrl, useSdk} from './useSdk';
 
 describe('useSdk', () => {
   it('adds a user agent header', () => {
@@ -14,5 +14,41 @@ describe('useSdk', () => {
 
     // Make sure __VERSION__ actually returns a version string
     expect(clientConfig.value?.headers?.['X-User-Agent']).toMatch(/MyParcelDeliveryOptions\/\d+\.\d+\.\d+/);
+  });
+
+  describe('setSdkBaseUrl', () => {
+    afterEach(() => {
+      setSdkBaseUrl(undefined);
+    });
+
+    it('does not set a base url by default', () => {
+      const {clientConfig} = useMockSdk();
+
+      useSdk();
+
+      expect(clientConfig.value?.baseUrl).toBeUndefined();
+    });
+
+    it('applies the base url to the sdk client', () => {
+      const {clientConfig} = useMockSdk();
+
+      setSdkBaseUrl('https://api.acceptance.myparcel.nl');
+      useSdk();
+
+      expect(clientConfig.value?.baseUrl).toBe('https://api.acceptance.myparcel.nl');
+    });
+
+    it('recreates the sdk client when the base url changes', () => {
+      const {clientConfig} = useMockSdk();
+
+      useSdk();
+
+      expect(clientConfig.value?.baseUrl).toBeUndefined();
+
+      setSdkBaseUrl('https://api.acceptance.myparcel.nl');
+      useSdk();
+
+      expect(clientConfig.value?.baseUrl).toBe('https://api.acceptance.myparcel.nl');
+    });
   });
 });

--- a/libs/shared/src/composables/useSdk.spec.ts
+++ b/libs/shared/src/composables/useSdk.spec.ts
@@ -1,5 +1,6 @@
 import {describe, it, expect, afterEach} from 'vitest';
 import {useMockSdk} from '../__tests__/useMockSdk';
+import {useCarriersRequest} from './sdk/useCarriersRequest';
 import {setSdkBaseUrl, useSdk} from './useSdk';
 
 describe('useSdk', () => {
@@ -36,6 +37,22 @@ describe('useSdk', () => {
       useSdk();
 
       expect(clientConfig.value?.baseUrl).toBe('https://api.acceptance.myparcel.nl');
+    });
+
+    it('does not serve cached responses after the base url changes', async () => {
+      const {history} = useMockSdk();
+
+      const firstRequest = useCarriersRequest();
+      await firstRequest.load();
+
+      expect(history.value).toHaveLength(1);
+
+      setSdkBaseUrl('https://api.acceptance.myparcel.nl');
+
+      const secondRequest = useCarriersRequest();
+      await secondRequest.load();
+
+      expect(history.value).toHaveLength(2);
     });
 
     it('recreates the sdk client when the base url changes', () => {

--- a/libs/shared/src/composables/useSdk.ts
+++ b/libs/shared/src/composables/useSdk.ts
@@ -8,9 +8,29 @@ import {
   GetPickupLocations,
 } from '@myparcel-dev/sdk';
 
+let sdkBaseUrl: string | undefined;
+
+/**
+ * Override the base url for all SDK requests (delivery options, carriers,
+ * pickup locations), e.g. to use an acceptance environment. This applies the
+ * `apiBaseUrl` config option. Pass undefined to restore the SDK's default url.
+ */
+export const setSdkBaseUrl = (url?: string): void => {
+  // An empty string also restores the default url.
+  const newUrl = url?.length ? url : undefined;
+
+  if (newUrl === sdkBaseUrl) {
+    return;
+  }
+
+  sdkBaseUrl = newUrl;
+  useSdk.clear();
+};
+
 export const useSdk = useMemoize(() => {
   return createPublicSdk(
     new FetchClient({
+      ...(sdkBaseUrl ? {baseUrl: sdkBaseUrl} : {}),
       headers: {
         'X-User-Agent': `MyParcelDeliveryOptions/${__VERSION__}`,
       },

--- a/libs/shared/src/composables/useSdk.ts
+++ b/libs/shared/src/composables/useSdk.ts
@@ -7,6 +7,8 @@ import {
   GetDeliveryOptions,
   GetPickupLocations,
 } from '@myparcel-dev/sdk';
+import {useRequestStorage} from './sdk/useRequestStorage';
+import {useRequest} from './sdk/useRequest';
 
 let sdkBaseUrl: string | undefined;
 
@@ -25,6 +27,11 @@ export const setSdkBaseUrl = (url?: string): void => {
 
   sdkBaseUrl = newUrl;
   useSdk.clear();
+
+  // Cached responses belong to the previous environment; the request cache is
+  // keyed by request only, not by base url.
+  useRequest.clear();
+  useRequestStorage().clear();
 };
 
 export const useSdk = useMemoize(() => {

--- a/libs/shared/src/data/constants.ts
+++ b/libs/shared/src/data/constants.ts
@@ -54,7 +54,7 @@ export const NBSP = '\u00A0';
 
 export const CARRIER_IDENTIFIER_SEPARATOR = ':';
 
-export const API_DATE_FORMAT = 'y-MM-dd kk:mm:ss';
+export const API_DATE_FORMAT = 'y-MM-dd HH:mm:ss';
 
 export const DEFAULT_TIMEZONE_TYPE = 3;
 

--- a/libs/shared/src/types/output.types.ts
+++ b/libs/shared/src/types/output.types.ts
@@ -1,7 +1,7 @@
 import type {SHIPMENT_OPTION_MAP} from '../utils';
 import {type Replace} from '@myparcel-dev/ts-utils';
 import {type DeliveryTypeName, type PackageTypeName, type ShipmentOptionName} from '@myparcel-dev/constants';
-import {type PickupLocationType} from '../data';
+import {type CustomDeliveryType, type PickupLocationType} from '../data';
 // Import directly from module to avoid circular dependency through barrel.
 import {type CarrierIdentifier} from './config.types';
 
@@ -9,18 +9,35 @@ type SnakeToCamel<S extends string> = S extends `${infer P}_${infer R}` ? `${P}$
 
 type ShipmentOptionsOutput = {
   [K in (typeof SHIPMENT_OPTION_MAP)[keyof typeof SHIPMENT_OPTION_MAP] as SnakeToCamel<K>]?: boolean;
+} & {
+  /**
+   * Set when a same-day moment is selected for a carrier whose capabilities
+   * expose same-day as a shipment option; emitted alongside the moment's actual
+   * delivery type. See {@link DeliveryDeliveryType} for carriers that expose
+   * same-day as a delivery type instead.
+   */
+  sameDayDelivery?: boolean;
 };
 
 interface BaseOutput {
   carrier: CarrierIdentifier;
   date?: string;
-  deliveryType: DeliveryTypeName;
+  deliveryType: DeliveryTypeName | CustomDeliveryType.SameDay;
   isPickup: boolean;
   packageType: PackageTypeName;
   shipmentOptions: ShipmentOptionsOutput;
 }
 
-export type DeliveryDeliveryType = DeliveryTypeName.Standard | DeliveryTypeName.Evening | DeliveryTypeName.Morning;
+/**
+ * Same-day is only emitted as a delivery type for carriers that expose it as a
+ * delivery type in their capabilities; carriers exposing it as an option emit
+ * their actual delivery type with the sameDayDelivery shipment option instead.
+ */
+export type DeliveryDeliveryType =
+  | DeliveryTypeName.Standard
+  | DeliveryTypeName.Evening
+  | DeliveryTypeName.Morning
+  | CustomDeliveryType.SameDay;
 
 export interface DeliveryOutput extends BaseOutput {
   deliveryType: DeliveryDeliveryType;

--- a/libs/shared/src/utils/capabilitiesMapping.spec.ts
+++ b/libs/shared/src/utils/capabilitiesMapping.spec.ts
@@ -13,7 +13,10 @@ import {
   mapCapabilityOptionToSdkParam,
   mapCapabilityOptionToCarrierSetting,
   mapCapabilityOptionToCustomDeliveryType,
-  mapCarrierSettingToCapabilityKey,
+  mapCarrierSettingToCapabilityKeys,
+  toDeliveryAllowKey,
+  toDeliveryPriceKey,
+  CAPABILITY_SETTINGS_PAIRS,
 } from './capabilitiesMapping';
 
 describe('normalizeCarrierName', () => {
@@ -35,6 +38,7 @@ describe('mapCapabilityDeliveryType / mapDeliveryTypeToCapability', () => {
     ['EVENING_DELIVERY', DeliveryTypeName.Evening],
     ['PICKUP_DELIVERY', DeliveryTypeName.Pickup],
     ['EXPRESS_DELIVERY', DeliveryTypeName.Express],
+    ['SAME_DAY_DELIVERY', CustomDeliveryType.SameDay],
   ] as const)('maps %s -> %s and back', (capType, sdkType) => {
     expect(mapCapabilityDeliveryType(capType)).toBe(sdkType);
     expect(mapDeliveryTypeToCapability(sdkType)).toBe(capType);
@@ -42,6 +46,11 @@ describe('mapCapabilityDeliveryType / mapDeliveryTypeToCapability', () => {
 
   it('returns undefined for unknown delivery type', () => {
     expect(mapCapabilityDeliveryType('NONEXISTENT')).toBeUndefined();
+  });
+
+  it('does not log for the same day delivery type', () => {
+    mapCapabilityDeliveryType('SAME_DAY_DELIVERY');
+    expect(consoleLogSpy).not.toHaveBeenCalled();
   });
 
   it('logs a debug message for unmapped delivery type', () => {
@@ -154,24 +163,50 @@ describe('mapCapabilityOptionToCustomDeliveryType', () => {
   });
 });
 
-describe('mapCarrierSettingToCapabilityKey', () => {
+describe('toDeliveryAllowKey / toDeliveryPriceKey', () => {
   it.each([
-    [CarrierSetting.AllowSignature, {type: 'option', name: 'requiresSignature'}],
-    [CarrierSetting.AllowOnlyRecipient, {type: 'option', name: 'recipientOnlyDelivery'}],
-    [CarrierSetting.AllowPriorityDelivery, {type: 'option', name: 'priorityDelivery'}],
-    [CarrierSetting.AllowStandardDelivery, {type: 'deliveryType', name: 'STANDARD_DELIVERY'}],
-    [CarrierSetting.AllowMorningDelivery, {type: 'deliveryType', name: 'MORNING_DELIVERY'}],
-    [CarrierSetting.AllowEveningDelivery, {type: 'deliveryType', name: 'EVENING_DELIVERY'}],
-    [CarrierSetting.AllowPickupLocations, {type: 'deliveryType', name: 'PICKUP_DELIVERY'}],
-    [CarrierSetting.AllowExpressDelivery, {type: 'deliveryType', name: 'EXPRESS_DELIVERY'}],
-    [CarrierSetting.AllowSameDayDelivery, {type: 'option', name: 'sameDayDelivery'}],
-    [CarrierSetting.AllowMondayDelivery, {type: 'option', name: 'mondayDelivery'}],
-    [CarrierSetting.AllowSaturdayDelivery, {type: 'option', name: 'saturdayDelivery'}],
-  ])('maps %s to correct shape', (setting, expected) => {
-    expect(mapCarrierSettingToCapabilityKey(setting)).toEqual(expected);
+    ['standard', CarrierSetting.AllowStandardDelivery, CarrierSetting.PriceStandardDelivery],
+    ['same_day', CarrierSetting.AllowSameDayDelivery, CarrierSetting.PriceSameDayDelivery],
+    ['pickup', CarrierSetting.AllowPickupLocations, CarrierSetting.PricePickup],
+  ] as const)('derives keys for %s', (sdkType, allowKey, priceKey) => {
+    expect(toDeliveryAllowKey(sdkType)).toBe(allowKey);
+    expect(toDeliveryPriceKey(sdkType)).toBe(priceKey);
+  });
+});
+
+describe('CAPABILITY_SETTINGS_PAIRS', () => {
+  it('contains no duplicate allow keys', () => {
+    const allowKeys = CAPABILITY_SETTINGS_PAIRS.map(([allow]) => allow);
+
+    expect(new Set(allowKeys).size).toBe(allowKeys.length);
+  });
+});
+
+describe('mapCarrierSettingToCapabilityKeys', () => {
+  it.each([
+    [CarrierSetting.AllowStandardDelivery, [{type: 'deliveryType', name: 'STANDARD_DELIVERY'}]],
+    [CarrierSetting.AllowMorningDelivery, [{type: 'deliveryType', name: 'MORNING_DELIVERY'}]],
+    [CarrierSetting.AllowEveningDelivery, [{type: 'deliveryType', name: 'EVENING_DELIVERY'}]],
+    [CarrierSetting.AllowPickupLocations, [{type: 'deliveryType', name: 'PICKUP_DELIVERY'}]],
+    [CarrierSetting.AllowExpressDelivery, [{type: 'deliveryType', name: 'EXPRESS_DELIVERY'}]],
+    [CarrierSetting.AllowSignature, [{type: 'option', name: 'requiresSignature'}]],
+    [CarrierSetting.AllowOnlyRecipient, [{type: 'option', name: 'recipientOnlyDelivery'}]],
+    [CarrierSetting.AllowPriorityDelivery, [{type: 'option', name: 'priorityDelivery'}]],
+    [CarrierSetting.AllowMondayDelivery, [{type: 'option', name: 'mondayDelivery'}]],
+    [CarrierSetting.AllowSaturdayDelivery, [{type: 'option', name: 'saturdayDelivery'}]],
+    [
+      // Same-day is exposed as a delivery type by some carriers and as an option by others.
+      CarrierSetting.AllowSameDayDelivery,
+      [
+        {type: 'deliveryType', name: 'SAME_DAY_DELIVERY'},
+        {type: 'option', name: 'sameDayDelivery'},
+      ],
+    ],
+  ])('maps %s to all capability representations', (setting, expected) => {
+    expect(mapCarrierSettingToCapabilityKeys(setting)).toEqual(expected);
   });
 
-  it('returns undefined for unmapped setting', () => {
-    expect(mapCarrierSettingToCapabilityKey(CarrierSetting.Collect)).toBeUndefined();
+  it('returns an empty array for unmapped settings', () => {
+    expect(mapCarrierSettingToCapabilityKeys(CarrierSetting.Collect)).toEqual([]);
   });
 });

--- a/libs/shared/src/utils/capabilitiesMapping.ts
+++ b/libs/shared/src/utils/capabilitiesMapping.ts
@@ -26,6 +26,7 @@ export const DELIVERY_TYPE_MAP: {
   readonly EVENING_DELIVERY: 'evening';
   readonly EXPRESS_DELIVERY: 'express';
   readonly PICKUP_DELIVERY: 'pickup';
+  readonly SAME_DAY_DELIVERY: 'same_day';
   /* eslint-enable @typescript-eslint/naming-convention */
 } = {
   STANDARD_DELIVERY: 'standard',
@@ -33,6 +34,10 @@ export const DELIVERY_TYPE_MAP: {
   EVENING_DELIVERY: 'evening',
   EXPRESS_DELIVERY: 'express',
   PICKUP_DELIVERY: 'pickup',
+  // Some carriers expose same-day as a delivery type instead of (or in addition
+  // to) the 'sameDayDelivery' option in DELIVERY_DAY_OPTION_MAP. Both map to the
+  // same internal type and the same allow/price/cutoff settings.
+  SAME_DAY_DELIVERY: 'same_day',
 };
 
 /** Capability option → SDK request param; allow/price settings follow the same convention. */
@@ -93,14 +98,15 @@ const capitalize = (str: string): string => str.charAt(0).toUpperCase() + str.sl
 const toPascalCase = (str: string): string => capitalize(toCamelCase(str));
 
 /**
- * Delivery types: 'standard' → allowStandardDelivery / priceStandardDelivery.
+ * Delivery types: 'standard' → allowStandardDelivery / priceStandardDelivery,
+ * 'same_day' → allowSameDayDelivery / priceSameDayDelivery.
  * Exception: 'pickup' → allowPickupLocations / pricePickup.
  */
 export const toDeliveryAllowKey = (sdk: string): CarrierSetting =>
-  sdk === 'pickup' ? CarrierSetting.AllowPickupLocations : (`allow${capitalize(sdk)}Delivery` as CarrierSetting);
+  sdk === 'pickup' ? CarrierSetting.AllowPickupLocations : (`allow${toPascalCase(sdk)}Delivery` as CarrierSetting);
 
 export const toDeliveryPriceKey = (sdk: string): CarrierSetting =>
-  sdk === 'pickup' ? CarrierSetting.PricePickup : (`price${capitalize(sdk)}Delivery` as CarrierSetting);
+  sdk === 'pickup' ? CarrierSetting.PricePickup : (`price${toPascalCase(sdk)}Delivery` as CarrierSetting);
 
 /**
  * Shipment options + delivery day SDK params:
@@ -159,7 +165,9 @@ export const CAPABILITY_SETTINGS_PAIRS: readonly [CarrierSetting, ConfigPriceKey
     toOptionAllowKey(sdk),
     toOptionPriceKey(sdk) as ConfigPriceKey,
   ]),
-];
+  // Same-day appears in both DELIVERY_TYPE_MAP and DELIVERY_DAY_OPTION_MAP and
+  // derives identical keys from both; keep the first occurrence of each pair.
+].filter(([allowKey], index, pairs) => pairs.findIndex(([other]) => other === allowKey) === index);
 
 // ─── Derived internal lookup tables ───────────────────────────────────────
 
@@ -211,27 +219,37 @@ const CAPABILITY_OPTION_TO_CUSTOM_DELIVERY_TYPE: Record<string, CustomDeliveryTy
   Object.entries(DELIVERY_DAY_OPTION_MAP).map(([capKey, sdkParam]) => [capKey, toCustomDeliveryType(sdkParam)]),
 );
 
-const CARRIER_SETTING_TO_CAPABILITY: Record<string, {type: 'deliveryType' | 'option'; name: string}> =
-  Object.fromEntries([
-    ...Object.entries(DELIVERY_TYPE_MAP).map(
-      ([capKey, sdk]): [string, {type: 'deliveryType' | 'option'; name: string}] => [
-        toDeliveryAllowKey(sdk),
-        {type: 'deliveryType', name: capKey},
-      ],
-    ),
-    ...Object.entries(DELIVERY_DAY_OPTION_MAP).map(
-      ([capKey, sdkParam]): [string, {type: 'deliveryType' | 'option'; name: string}] => [
-        toOptionAllowKey(sdkParam),
-        {type: 'option', name: capKey},
-      ],
-    ),
-    ...Object.entries(SHIPMENT_OPTION_MAP).map(
-      ([capKey, sdk]): [string, {type: 'deliveryType' | 'option'; name: string}] => [
-        toOptionAllowKey(sdk),
-        {type: 'option', name: capKey},
-      ],
-    ),
-  ]);
+/** How a carrier setting is represented in a capabilities response. */
+export interface CarrierSettingCapabilityKey {
+  type: 'deliveryType' | 'option';
+  name: string;
+}
+
+const CARRIER_SETTING_CAPABILITY_ENTRIES: [string, CarrierSettingCapabilityKey][] = [
+  ...Object.entries(DELIVERY_TYPE_MAP).map(([capKey, sdk]): [string, CarrierSettingCapabilityKey] => [
+    toDeliveryAllowKey(sdk),
+    {type: 'deliveryType', name: capKey},
+  ]),
+  ...Object.entries(DELIVERY_DAY_OPTION_MAP).map(([capKey, sdkParam]): [string, CarrierSettingCapabilityKey] => [
+    toOptionAllowKey(sdkParam),
+    {type: 'option', name: capKey},
+  ]),
+  ...Object.entries(SHIPMENT_OPTION_MAP).map(([capKey, sdk]): [string, CarrierSettingCapabilityKey] => [
+    toOptionAllowKey(sdk),
+    {type: 'option', name: capKey},
+  ]),
+];
+
+/**
+ * A carrier setting can have multiple capability representations: same-day is a
+ * delivery type on some carriers and an option on others.
+ */
+const CARRIER_SETTING_TO_CAPABILITIES: Record<string, CarrierSettingCapabilityKey[]> =
+  CARRIER_SETTING_CAPABILITY_ENTRIES.reduce((acc, [settingKey, capability]) => {
+    (acc[settingKey] ??= []).push(capability);
+
+    return acc;
+  }, {} as Record<string, CarrierSettingCapabilityKey[]>);
 
 // ─── Reverse maps ──────────────────────────────────────────────────────────
 
@@ -320,11 +338,12 @@ export const mapPackageTypeToCapability = (sdkType: string): string | undefined 
   SDK_PACKAGE_TYPE_TO_CAPABILITY[sdkType];
 
 /**
- * Map a CarrierSetting allow key to its capabilities equivalent.
+ * Map a CarrierSetting allow key to all its capability representations. Same-day
+ * delivery is exposed as a delivery type by some carriers and as an option by
+ * others; a carrier supports the setting when any representation matches.
  */
-export const mapCarrierSettingToCapabilityKey = (
-  setting: CarrierSetting,
-): {type: 'deliveryType' | 'option'; name: string} | undefined => CARRIER_SETTING_TO_CAPABILITY[setting];
+export const mapCarrierSettingToCapabilityKeys = (setting: CarrierSetting): CarrierSettingCapabilityKey[] =>
+  CARRIER_SETTING_TO_CAPABILITIES[setting] ?? [];
 
 /**
  * Map capabilities delivery-day options to their corresponding CustomDeliveryType values.
@@ -345,7 +364,9 @@ export const getCapabilityDeliveryTypes = (cap: CarrierCapability): SupportedDel
   for (const optionName of Object.keys(cap.options)) {
     const customType = mapCapabilityOptionToCustomDeliveryType(optionName);
 
-    if (customType) {
+    // A carrier may expose same-day both as a delivery type and as an option;
+    // the delivery-type mapping above already added it in that case.
+    if (customType && !mapped.includes(customType)) {
       mapped.push(customType);
     }
   }

--- a/libs/shared/src/utils/getAllConfigOptions.spec.ts
+++ b/libs/shared/src/utils/getAllConfigOptions.spec.ts
@@ -1,0 +1,12 @@
+import {describe, it, expect} from 'vitest';
+import {CarrierSetting, OptionType} from '../data';
+import {getAllConfigOptions} from './getAllConfigOptions';
+
+describe('getAllConfigOptions', () => {
+  it('declares the same day cutoff time option', () => {
+    const option = getAllConfigOptions().find((item) => item.key === CarrierSetting.CutoffTimeSameDay);
+
+    expect(option).toBeDefined();
+    expect(option?.type).toBe(OptionType.Time);
+  });
+});

--- a/libs/shared/src/utils/getAllConfigOptions.ts
+++ b/libs/shared/src/utils/getAllConfigOptions.ts
@@ -37,6 +37,11 @@ export const getAllConfigOptions = useMemoize((): ConfigOption[] => [
   }),
 
   declareOption({
+    key: CarrierSetting.CutoffTimeSameDay,
+    type: OptionType.Time,
+  }),
+
+  declareOption({
     key: ConfigSetting.PickupLocationsDefaultView,
     type: OptionType.Select,
   }),


### PR DESCRIPTION
adds support for carriers that expose same-day delivery as a delivery type in their capabilities, like Trunkrs.

Until now the widget only understood same-day as a shipment option (like DHL For You), so a delivery-type carrier rendered a bogus standard delivery fallback or nothing at all. Both representations now map to the same internal same_day type and share one set of allow/price/cutoff settings. Carriers the legacy delivery options API does not support yet get a synthetic "today" moment as long as their same-day cutoff has not passed, the standard delivery fallback only shows for carriers that actually support standard delivery, and the same-day cutoff is resolved from the current drop-off day. The selection is emitted the way the carrier represents it: as the same_day delivery type, or as the sameDayDelivery shipment option combined with the original delivery type. The sandbox shows the same-day toggle and cutoff field for both representations.

On top of that, the SDK requests (delivery options, carriers, pickup locations) now follow the documented apiBaseUrl config option instead of always using the production url, and the sandbox got an API base url field so it can be used against other environments (e.g. acceptance) with a matching API key.

Note: the deliverySameDayTitle string and the sandbox api_base_url_header label still need entries in the translations catalogue.

Fixes INT-1561

🤖 Generated with [Claude Code](https://claude.com/claude-code)