### PR TITLE
fix: derive monday and saturday delivery from carrier settings

### DIFF
--- a/apps/delivery-options/src/utils/createGetDeliveryOptionsParameters.spec.ts
+++ b/apps/delivery-options/src/utils/createGetDeliveryOptionsParameters.spec.ts
@@ -71,6 +71,8 @@ describe('createGetDeliveryOptionsParameters', () => {
         dropoff_days: '0;2;3;4',
         dropoff_delay: 0,
         same_day_delivery: true,
+        // Inherited from the global allowMondayDelivery default.
+        monday_delivery: true,
         include: 'shipment_options',
       },
     },
@@ -84,6 +86,8 @@ describe('createGetDeliveryOptionsParameters', () => {
         deliverydays_window: 7,
         dropoff_days: '1;2;3;4;5',
         dropoff_delay: 1,
+        // Inherited from the global allowMondayDelivery default.
+        monday_delivery: true,
         include: 'shipment_options',
       },
     },
@@ -112,6 +116,56 @@ describe('createGetDeliveryOptionsParameters', () => {
         },
         output,
       ),
+    );
+  });
+
+  /**
+   * Monday and Saturday delivery are query parameters of the delivery_options
+   * endpoint, not carrier capabilities, so they are absent from the capabilities
+   * response. They must be driven by the carrier settings alone — gating them on
+   * capabilities meant they were never sent at all.
+   */
+  describe('extra delivery days are not gated on capabilities', () => {
+    it.each([
+      [CarrierSetting.AllowMondayDelivery, 'monday_delivery'],
+      [CarrierSetting.AllowSaturdayDelivery, 'saturday_delivery'],
+    ] satisfies [CarrierSetting, keyof EndpointParameters<GetDeliveryOptions>][])(
+      'sends %s as %s when enabled in the carrier settings',
+      async (setting, parameter) => {
+        expect.assertions(1);
+
+        mockDeliveryOptionsConfig(
+          getMockDeliveryOptionsConfiguration({
+            [KEY_CONFIG]: {[KEY_CARRIER_SETTINGS]: {[CarrierName.PostNl]: {[setting]: true}}},
+          }),
+        );
+
+        const resolvedCarrier = getResolvedCarrier(CarrierName.PostNl);
+        await flushPromises();
+
+        expect(createGetDeliveryOptionsParameters(resolvedCarrier)[parameter]).toBe(true);
+      },
+    );
+
+    it.each([
+      [CarrierSetting.AllowMondayDelivery, 'monday_delivery'],
+      [CarrierSetting.AllowSaturdayDelivery, 'saturday_delivery'],
+    ] satisfies [CarrierSetting, keyof EndpointParameters<GetDeliveryOptions>][])(
+      'omits %s when disabled in the carrier settings',
+      async (setting, parameter) => {
+        expect.assertions(1);
+
+        mockDeliveryOptionsConfig(
+          getMockDeliveryOptionsConfiguration({
+            [KEY_CONFIG]: {[KEY_CARRIER_SETTINGS]: {[CarrierName.PostNl]: {[setting]: false}}},
+          }),
+        );
+
+        const resolvedCarrier = getResolvedCarrier(CarrierName.PostNl);
+        await flushPromises();
+
+        expect(createGetDeliveryOptionsParameters(resolvedCarrier)).not.toHaveProperty(parameter);
+      },
     );
   });
 

--- a/apps/delivery-options/src/utils/getResolvedCarrier.spec.ts
+++ b/apps/delivery-options/src/utils/getResolvedCarrier.spec.ts
@@ -40,7 +40,9 @@ describe('getResolvedCarrier', () => {
 
       await flushPromises();
 
-      expect(carrier.deliveryTypes.value).toEqual(new Set([DeliveryTypeName.Evening, DeliveryTypeName.Standard]));
+      expect(carrier.deliveryTypes.value).toEqual(
+        new Set([CustomDeliveryType.Monday, DeliveryTypeName.Evening, DeliveryTypeName.Standard]),
+      );
     });
 
     it('filters delivery types by config', async () => {
@@ -62,6 +64,7 @@ describe('getResolvedCarrier', () => {
 
       expect(carrier.deliveryTypes.value).toEqual(
         new Set([
+          CustomDeliveryType.Monday,
           CustomDeliveryType.SameDay,
           DeliveryTypeName.Evening,
           DeliveryTypeName.Pickup,
@@ -91,7 +94,12 @@ describe('getResolvedCarrier', () => {
       carrier.disabledDeliveryTypes.value.add(DeliveryTypeName.Standard);
 
       expect(carrier.deliveryTypes.value).toEqual(
-        new Set([CustomDeliveryType.SameDay, DeliveryTypeName.Evening, DeliveryTypeName.Pickup]),
+        new Set([
+          CustomDeliveryType.Monday,
+          CustomDeliveryType.SameDay,
+          DeliveryTypeName.Evening,
+          DeliveryTypeName.Pickup,
+        ]),
       );
     });
   });
@@ -186,6 +194,7 @@ describe('getResolvedCarrier', () => {
     expect(carrier.features.value).toEqual(
       new Set([
         CarrierSetting.AllowEveningDelivery,
+        CarrierSetting.AllowMondayDelivery,
         CarrierSetting.AllowOnlyRecipient,
         CarrierSetting.AllowPickupLocations,
         CarrierSetting.AllowSameDayDelivery,
@@ -210,7 +219,11 @@ describe('getResolvedCarrier', () => {
     );
 
     expect(carrier.features.value).toEqual(
-      new Set([CarrierSetting.AllowEveningDelivery, CarrierSetting.AllowPickupLocations]),
+      new Set([
+        CarrierSetting.AllowEveningDelivery,
+        CarrierSetting.AllowMondayDelivery,
+        CarrierSetting.AllowPickupLocations,
+      ]),
     );
   });
 

--- a/apps/delivery-options/src/utils/getResolvedCarrier.ts
+++ b/apps/delivery-options/src/utils/getResolvedCarrier.ts
@@ -11,6 +11,7 @@ import {
   type ConfigKey,
   normalizeCarrierName,
   resolveCarrierName,
+  EXTRA_DELIVERY_DAY_TYPES,
   computedAsync,
   waitForRequestData,
   useCarrierFromCache,
@@ -92,8 +93,17 @@ export const getResolvedCarrier = useMemoize(
     /** Mutable set of delivery types currently disabled (e.g. due to API errors). */
     const disabledDeliveryTypes = ref(new Set<SupportedDeliveryTypeName>());
 
-    /** Derive delivery types directly from capabilities for reliable reactivity. */
-    const allDeliveryTypes = computed(() => fromCapability((cap) => new Set(getCapabilityDeliveryTypes(cap))));
+    /**
+     * Derive delivery types directly from capabilities for reliable reactivity.
+     *
+     * The extra delivery days (Monday/Saturday) are added unconditionally: they
+     * are delivery_options query parameters, not carrier capabilities, so the
+     * capabilities response never reports them. `deliveryTypes` below still
+     * filters them on the merchant's allow* settings.
+     */
+    const allDeliveryTypes = computed(() =>
+      fromCapability((cap) => new Set([...getCapabilityDeliveryTypes(cap), ...EXTRA_DELIVERY_DAY_TYPES])),
+    );
 
     /** Delivery types this carrier supports, filtered by config settings. */
     const deliveryTypes = computed(() => {

--- a/apps/sandbox/src/form/availableInPlatform.spec.ts
+++ b/apps/sandbox/src/form/availableInPlatform.spec.ts
@@ -81,6 +81,22 @@ describe('availableInCarrier', () => {
     expect(availableInCarrier(`postnl.${CarrierSetting.AllowSignature}`)).toBe(false);
   });
 
+  describe('monday delivery', () => {
+    // No carrier reports mondayDelivery as a capability, so the sandbox keeps its
+    // own list of carriers that support it.
+    it('returns true for PostNL', () => {
+      __setMockCapabilities([createCapability('postnl', ['STANDARD_DELIVERY'], {})]);
+
+      expect(availableInCarrier(`postnl.${CarrierSetting.AllowMondayDelivery}`)).toBe(true);
+    });
+
+    it.each(['dpd', 'dhlforyou', 'upsstandard'])('returns false for %s', (carrier) => {
+      __setMockCapabilities([createCapability(carrier, ['STANDARD_DELIVERY'], {})]);
+
+      expect(availableInCarrier(`${carrier}.${CarrierSetting.AllowMondayDelivery}`)).toBe(false);
+    });
+  });
+
   it('returns true when no capability data is available for the carrier', () => {
     __setMockCapabilities([]);
 

--- a/apps/sandbox/src/form/availableInPlatform.ts
+++ b/apps/sandbox/src/form/availableInPlatform.ts
@@ -1,5 +1,16 @@
 import {type CarrierSetting, mapCarrierSettingToCapabilityKeys} from '@myparcel-dev/do-shared';
+import {CarrierName} from '@myparcel-dev/constants';
 import {useSandboxCapabilities} from '../composables';
+
+/**
+ * Monday delivery is a delivery_options query parameter, not a carrier
+ * capability, so the capabilities response cannot tell us which carriers support
+ * it. Keep an explicit list here so the sandbox only offers the toggle where it
+ * actually does something.
+ */
+const EXTRA_DELIVERY_DAY_CARRIERS: Readonly<Record<string, readonly string[]>> = Object.freeze({
+  mondayDelivery: [CarrierName.PostNl],
+});
 
 /**
  * Check if a given carrier setting is supported by the carrier's capabilities.
@@ -30,7 +41,17 @@ export const availableInCarrier = (fieldPath: string): boolean => {
     return true;
   }
 
-  return capMappings.some((capMapping) =>
-    capMapping.type === 'deliveryType' ? cap.deliveryTypes.includes(capMapping.name) : capMapping.name in cap.options,
-  );
+  return capMappings.some((capMapping) => {
+    if (capMapping.type === 'deliveryType') {
+      return cap.deliveryTypes.includes(capMapping.name);
+    }
+
+    const supportedCarriers = EXTRA_DELIVERY_DAY_CARRIERS[capMapping.name];
+
+    if (supportedCarriers) {
+      return supportedCarriers.includes(carrierName);
+    }
+
+    return capMapping.name in cap.options;
+  });
 };

--- a/libs/shared/src/__tests__/mocks/mockCapabilitiesResponse.ts
+++ b/libs/shared/src/__tests__/mocks/mockCapabilitiesResponse.ts
@@ -8,6 +8,11 @@ const DEFAULT_OPTION = {
   isRequired: false,
 };
 
+/**
+ * Mirrors the live capabilities v2 response. Note that `mondayDelivery` is
+ * deliberately absent: Monday delivery is an endpoint query parameter, not a
+ * carrier capability, so no carrier ever reports it.
+ */
 export const MOCK_CAPABILITIES: CarrierCapability[] = [
   {
     carrier: 'POSTNL',
@@ -17,7 +22,6 @@ export const MOCK_CAPABILITIES: CarrierCapability[] = [
       requiresSignature: {...DEFAULT_OPTION},
       recipientOnlyDelivery: {...DEFAULT_OPTION, requires: ['requiresSignature']},
       priorityDelivery: {...DEFAULT_OPTION},
-      mondayDelivery: {...DEFAULT_OPTION},
     },
     collo: {max: 10},
   },

--- a/libs/shared/src/utils/capabilitiesMapping.ts
+++ b/libs/shared/src/utils/capabilitiesMapping.ts
@@ -51,6 +51,18 @@ export const DELIVERY_DAY_OPTION_MAP: {
   saturdayDelivery: 'saturday_delivery',
 };
 
+/**
+ * Delivery days that are *extra options* rather than carrier capabilities: they
+ * are query parameters of the delivery_options endpoint that hint whether the
+ * day may be offered at all. The capabilities v2 contract does not describe
+ * them, so they must be driven by merchant config alone — gating them on
+ * capabilities means they are never enabled.
+ *
+ * `sameDayDelivery` is deliberately not listed: carriers do report same-day, as
+ * an option or as a delivery type, so it belongs in the capabilities response.
+ */
+const EXTRA_DELIVERY_DAY_OPTION_KEYS = Object.freeze(['mondayDelivery', 'saturdayDelivery'] as const);
+
 export const SHIPMENT_OPTION_MAP: {
   readonly requiresSignature: 'signature';
   readonly recipientOnlyDelivery: 'only_recipient';
@@ -142,6 +154,14 @@ export const SUPPORTED_DELIVERY_TYPES = Object.freeze(Object.values(DELIVERY_TYP
  * Replaces the hardcoded SUPPORTED_SHIPMENT_OPTIONS array in constants.ts.
  */
 export const SUPPORTED_SHIPMENT_OPTIONS = Object.freeze(Object.values(SHIPMENT_OPTION_MAP));
+
+/**
+ * Custom delivery types for the extra delivery days — available to every
+ * carrier, subject to merchant config only.
+ */
+export const EXTRA_DELIVERY_DAY_TYPES: readonly CustomDeliveryType[] = Object.freeze(
+  EXTRA_DELIVERY_DAY_OPTION_KEYS.map((key) => toCustomDeliveryType(DELIVERY_DAY_OPTION_MAP[key])),
+);
 
 /** All shipment options default to allowed. Auto-derived from SHIPMENT_OPTION_MAP. */
 export const SHIPMENT_OPTION_ALLOW_DEFAULTS = Object.fromEntries(


### PR DESCRIPTION
INT-1772

## Summary

The PostNL "Monday delivery" setting had no effect: the widget never sent
`monday_delivery` to the delivery options endpoint, so Monday was never offered as a
delivery date regardless of the merchant's configuration. Reported for Magento 2, but
the cause is in this widget and affects every integration.

## Root cause

`monday_delivery` is read from `features`, which is derived from `deliveryTypes` →
`allDeliveryTypes` → `getCapabilityDeliveryTypes(cap)`. That function only adds
`monday` when `cap.options` contains the key `mondayDelivery`.

That key does not exist in the capabilities v2 contract, and it should not: Monday
delivery is a **query parameter of the delivery_options endpoint**, not a carrier
capability. The SDK classifies it accordingly — `EXTRA_OPTION_DELIVERY_MONDAY`, next
to `EXTRA_OPTION_DELIVERY_SATURDAY`, whereas only `SHIPMENT_OPTION_SAME_DAY_DELIVERY`
is a real shipment option. So the key never arrives, `allowMondayDelivery` never lands
in `features`, and the parameter is dropped.

This is a regression from the v7 capabilities migration (f3f2534). Before it, PostNL's
platform configuration listed `CustomDeliveryType.Monday` in its hardcoded
`deliveryTypes`; that list was replaced by the capabilities response and Monday fell
through the gap. Saturday had the same treatment (Bpost and PostNL on sendmyparcel).

The test suite stayed green because the PostNL mock capability reported
`mondayDelivery` — something the live API never does.

## Changes

- **`capabilitiesMapping.ts`** — `EXTRA_DELIVERY_DAY_TYPES` marks Monday and Saturday
  as extra delivery days rather than capabilities. `sameDayDelivery` is deliberately
  excluded; that one is a genuine shipment option and does belong in capabilities.
- **`getResolvedCarrier.ts`** — extra delivery days are added to `allDeliveryTypes`
  unconditionally; the existing config filter in `deliveryTypes` decides whether they
  are actually enabled.
- **`availableInPlatform.ts`** (sandbox) — the Monday toggle is offered for PostNL
  only, via an explicit allowlist. Capabilities cannot say which carriers support it,
  which is the whole point of this fix, so the sandbox keeps its own list.
- **`mockCapabilitiesResponse.ts`** — the PostNL mock no longer reports
  `mondayDelivery`, so it mirrors the live response. This is what made the bug
  reproducible in the suite.

Besides restoring the request parameter, this also restores pricing: Monday dates
resolve to `CustomDeliveryType.Monday` again, so `priceMondayDelivery` applies instead
of the standard rate.

## Behaviour change worth reviewing

`getDefaultDeliveryOptionsConfig` sets `allowMondayDelivery: true` globally. While
Monday was gated on capabilities that default was inert; now it means a merchant who
does not configure the setting sends `monday_delivery=1` for **all** their carriers,
where v6 limited it to PostNL. This only becomes visible for merchants who have
Saturday as a drop-off day, and the API remains the authority on whether Monday is
actually deliverable for a given carrier. Chosen deliberately over removing the
default, which would have been a breaking change for integrators relying on it. Two
tests document the effect explicitly.

## Testing

- New regression tests assert that both `monday_delivery` and `saturday_delivery` are
  sent for a carrier whose capabilities do not report them, and omitted when the
  carrier setting is off.
- New sandbox tests assert the Monday toggle shows for PostNL and not for other
  carriers.
- `yarn test:run --skip-nx-cache` — 570 tests pass across all three projects.
- Verified in the sandbox with an API key: the Monday toggle appears for PostNL only
  and reaches the resolved configuration.
- Typecheck is unchanged at 88 pre-existing errors, none in the touched files.

## Out of scope

- Without an API key the sandbox loads no capabilities and falls back to showing every
  toggle for every carrier, Monday included. Pre-existing behaviour, tracked
  separately.
- `same_day_delivery` is gated the same way, and PostNL does not report
  `sameDayDelivery` in its capabilities either. That is an API-side question rather
  than a widget one and needs its own ticket.
- The `saturdayDelivery` capability key is reported by DHL Europlus and DPD even though
  the SDK classifies Saturday as an extra option. The ticket notes this as an
  API-side inconsistency; the sandbox toggle for Saturday is left as is.
